### PR TITLE
v0.6.0 — semantic checks in the editor, engine consumed from npm

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -6,7 +6,11 @@
 .gitattributes
 .claude/**
 
-# Dependencies
+# Dependencies.
+# node_modules is excluded wholesale, but RUNTIME dependencies must ship or the
+# extension dies at activation with "Cannot find module". This was caught by
+# extracting the VSIX and executing the packaged code — the file listing looked
+# perfectly fine.
 node_modules/**
 
 # Coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.6.0] - 2026-08-07
+
+### ✨ Semantic checks — defects that compile and are still wrong
+
+Until now this extension caught code TradingView would reject. These catch code it
+**accepts** and then behaves unexpectedly — the category that costs money rather
+than time.
+
+| ID | Detects | Severity |
+|---|---|---|
+| **S1** | `request.security()` reading the current, still-forming bar — repainting | Warning |
+| **S2** | `ta.*` called inside a ternary or block — its history develops gaps | Warning |
+| **S5** | More than 64 plot calls — TradingView rejects the script | Error |
+| **S6** | More than 40 `request.*()` calls | Error |
+| **S7** | `plot` / `bgcolor` / `fill` outside global scope — a v6 scope error | Error |
+| **S8** | A function defined inside a block — Pine has no nested functions | Error |
+| **S9** | `strategy.entry` with no exit anywhere — unbounded risk | Warning |
+
+Suppress a finding you have considered:
+
+```pine
+d = request.security(t, "D", close)   // pine-ignore: S1
+```
+
+Syntactic diagnostics are never suppressible — a compile error is a fact, not a
+judgement.
+
+### 🔧 Architecture
+
+The validation engine is now published as
+[`pinescript-v6-validator`](https://www.npmjs.com/package/pinescript-v6-validator)
+and consumed by this extension rather than duplicated. A check is written once;
+the editor renders it and agent tooling returns it. Two copies would drift, and a
+drifted rule means your agent and your editor disagree about the same file.
+
+### 🐛 Found by the new checks
+
+`examples/indicator.2.3.pine` called `bgcolor()` inside an `if` — a genuine v6
+scope error, twelve lines above code in the same file doing it correctly.
+
+---
+
 ## [0.5.1] - 2026-08-07
 
 Packaging release. **No validator behaviour changes from 0.5.0** — the version is

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Search for **"Pine Script v6 IDE Tools"** in VS Code Extensions or [install dire
 ### Or Install from VSIX
 Download the latest `.vsix` from [Releases](https://github.com/jpantsjoha/pinescript-vscode-extension/releases) and install:
 ```bash
-code --install-extension pinescript-v6-extension-0.5.1.vsix
+code --install-extension pinescript-v6-extension-0.6.0.vsix
 ```
 
 ---
@@ -37,6 +37,15 @@ code --install-extension pinescript-v6-extension-0.5.1.vsix
 - **31 constant namespaces** (xloc, yloc, extend, scale, display, etc.)
 - **22 function namespaces** with full parameter validation
 - **32 strategy.* variables** (position_size, equity, netprofit, etc.)
+
+### 🧠 **Semantic checks — catches code that compiles and is still wrong**
+- **Repainting** — `request.security()` reading the current, forming bar
+- **`ta.*` in a conditional** — silently corrupts the indicator's own history
+- **Scope errors** — `plot`/`bgcolor` inside `if`, functions defined in a block
+- **Platform limits** — 64 plots, 40 `request.*()` calls, counted before TradingView rejects you
+- **Unbounded risk** — `strategy.entry` with no exit anywhere
+
+Suppress one you have considered: `// pine-ignore: S1`
 
 ### 🔍 **Real-Time Validation**
 - Catches undefined functions and variables
@@ -141,7 +150,7 @@ See [CHANGELOG](./CHANGELOG.md) for complete version history.
 
 ## 🧪 Testing
 
-- **112/112 tests passing** (100%)
+- **169/169 tests passing** (100%)
 - **Golden corpus**: 13 real scripts that compile on TradingView, asserted to
   produce zero errors — any error against them is a false positive by definition
 - **Paired regression tests**: every false-positive fix ships with a "must still
@@ -213,5 +222,5 @@ Special thanks to:
 ---
 
 **Full Language Coverage**: 6,665 Pine Script v6 constructs
-**Test Coverage**: 112 tests
-**Current Version**: 0.5.1
+**Test Coverage**: 169 tests
+**Current Version**: 0.6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "pinescript-v6-extension",
-  "version": "0.4.3",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pinescript-v6-extension",
-      "version": "0.4.3",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "glob": "^11.0.3"
+        "glob": "^11.0.3",
+        "pinescript-v6-validator": "^0.2.0"
       },
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",
@@ -1275,6 +1276,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pinescript-v6-validator": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/pinescript-v6-validator/-/pinescript-v6-validator-0.2.0.tgz",
+      "integrity": "sha512-86X7N5u8y563ZtQJW988ANSurHOi/skAh0p+mAS2xmnGBdWUy+pbcX0RT/h+LKkoz+yZfUrjy04nlicbQtXU0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/pkce-challenge": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "Jaroslav Pantsjoha",
     "url": "https://jpantsjoha.com"
   },
-  "version": "0.5.1",
+  "version": "0.6.0",
   "icon": "images/pinescript-extension.png",
   "repository": {
     "type": "git",
@@ -116,7 +116,7 @@
   },
   "scripts": {
     "clean": "rm -rf dist && rm -f build/*.vsix",
-    "build": "tsc -p . && tsc -p packages/validator",
+    "build": "tsc -p . && tsc -p packages/validator && rm -rf dist/engine && mkdir -p dist/engine && cp -R node_modules/pinescript-v6-validator/dist/* dist/engine/",
     "watch": "tsc -w -p .",
     "test": "npm run build && node --test test/*.test.js",
     "test:validation": "npm run build && node --test test/validation.test.js",
@@ -142,6 +142,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "glob": "^11.0.3"
+    "glob": "^11.0.3",
+    "pinescript-v6-validator": "^0.2.0"
   }
 }

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -34,6 +34,29 @@ PINE_FUNCTIONS_MERGED['line.new'].overloads;
 // Both official call forms: (first_point, second_point, …) and (x1, y1, x2, y2, …)
 ```
 
+## Semantic checks — defects that compile
+
+Most Pine tooling catches code TradingView will reject. These catch code it
+**accepts** and then behaves unexpectedly:
+
+| ID | Detects |
+|---|---|
+| S1 | `request.security()` reading the current, still-forming bar — repainting |
+| S2 | `ta.*` called inside a conditional — its history develops gaps |
+| S5 / S6 | More than 64 plots or 40 `request.*()` calls — TradingView rejects the script |
+| S7 | `plot` / `bgcolor` / `fill` outside global scope — a v6 scope error |
+| S8 | A function defined inside a block — Pine has no nested functions |
+| S9 | `strategy.entry` with no exit anywhere — unbounded risk |
+
+Suppress a specific finding when you have considered it:
+
+```pine
+d = request.security(t, "D", close)   // pine-ignore: S1
+```
+
+Syntactic diagnostics are never suppressible — a compile error is a fact, not a
+judgement.
+
 ## What it catches
 
 - **Overloaded constructors.** `line.new`, `label.new` and `box.new` each accept a

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,20 +1,46 @@
 {
   "name": "pinescript-v6-validator",
-  "version": "0.1.0",
-  "description": "TradingView Pine Script v6 validator and reference dataset — 457 function signatures with explicit overload modelling. The engine behind the Pine Script v6 IDE Tools VS Code extension.",
-  "keywords": ["pinescript", "pine-script", "pine-v6", "tradingview", "validator", "linter", "trading", "indicators"],
-  "author": { "name": "Jaroslav Pantsjoha", "url": "https://jpantsjoha.com" },
+  "version": "0.2.0",
+  "description": "TradingView Pine Script v6 validator and reference dataset \u2014 457 function signatures with explicit overload modelling. The engine behind the Pine Script v6 IDE Tools VS Code extension.",
+  "keywords": [
+    "pinescript",
+    "pine-script",
+    "pine-v6",
+    "tradingview",
+    "validator",
+    "linter",
+    "trading",
+    "indicators"
+  ],
+  "author": {
+    "name": "Jaroslav Pantsjoha",
+    "url": "https://jpantsjoha.com"
+  },
   "license": "MIT",
   "homepage": "https://github.com/jpantsjoha/pinescript-vscode-extension",
-  "repository": { "type": "git", "url": "git+https://github.com/jpantsjoha/pinescript-vscode-extension.git", "directory": "packages/validator" },
-  "bugs": { "url": "https://github.com/jpantsjoha/pinescript-vscode-extension/issues" },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jpantsjoha/pinescript-vscode-extension.git",
+    "directory": "packages/validator"
+  },
+  "bugs": {
+    "url": "https://github.com/jpantsjoha/pinescript-vscode-extension/issues"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": ["dist", "README.md", "LICENSE"],
-  "engines": { "node": ">=18" },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "build": "tsc -p .",
     "prepublishOnly": "npm run build && node -e \"require('./dist/index.js')\""
   },
-  "devDependencies": { "typescript": "^5.4.5" }
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
 }

--- a/scripts/audit.js
+++ b/scripts/audit.js
@@ -318,6 +318,12 @@ function auditDiagnosticCoverage() {
     .map(f => f.replace(/\.ts$/, ''))
     .filter(name => new RegExp(`from '\\./parser/${name}'`).test(extension));
 
+  // Since ADR-0001 the semantic checks live in the published engine rather than
+  // src/parser/, so they are named by their package import instead of a local file.
+  if (/from 'pinescript-v6-validator'/.test(extension)) {
+    sources.push('runSemanticChecks');
+  }
+
   if (!sources.length) {
     warn('diagnostics', 'could not identify any diagnostic source imported by extension.ts');
     return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,12 @@ import { createSignatureHelpProvider } from './signatureHelp';
 // without also being covered by validate-cli.js and the golden corpus. See STATUS.md.
 import { AccurateValidator } from './parser/accurateValidator';
 import { runDocumentChecks } from './parser/documentChecks';
+// Semantic checks come from the published engine rather than a local copy.
+// ADR-0001: a check is written once, in the engine. Two copies drift, and a
+// drifted rule means the editor and the agent disagree about the same file.
+// Resolved at runtime from dist/engine, which the build copies from the pinned
+// npm package. Same single source; avoids shipping node_modules in the VSIX.
+const engine = require('../engine/index.js');
 
 export function activate(context: vscode.ExtensionContext) {
   // Optional: ensure files.associations maps *.pine -> pine
@@ -188,6 +194,20 @@ export function activate(context: vscode.ExtensionContext) {
       }
     } catch (e) {
       console.error('[Pine Validator] Validation error:', e);
+    }
+
+    // Semantic checks — defects that compile and are still wrong (repainting,
+    // ta.* history gaps, scope violations). Suppressions are read from the RAW
+    // text, before any pass blanks the comments the directives live in.
+    try {
+      const suppressions = engine.extractSuppressions(text);
+      for (const check of engine.applySuppressions(engine.runSemanticChecks(text), suppressions)) {
+        const pos = new vscode.Position(check.line - 1, check.column);
+        const endPos = pos.translate(0, check.length);
+        diags.push(new vscode.Diagnostic(new vscode.Range(pos, endPos), check.message, check.severity));
+      }
+    } catch (e) {
+      console.error('[Pine Validator] Semantic check error:', e);
     }
 
     // Whole-document heuristic checks. Extracted to src/parser/documentChecks.ts so

--- a/test/golden-corpus.test.js
+++ b/test/golden-corpus.test.js
@@ -25,7 +25,14 @@ const { runDocumentChecks } = require('../dist/src/parser/documentChecks.js');
  * first is how 28 false `alertcondition` errors survived a "0 errors" corpus run.
  */
 function allDiagnostics(source) {
-  return [...new AccurateValidator().validate(source), ...runDocumentChecks(source)];
+  // All THREE sources. validatePineScript from the engine aggregates the semantic
+  // checks and applies suppressions; the two extension-local modules are added
+  // here so the gate reflects exactly what a user sees in the editor.
+  return [
+    ...new AccurateValidator().validate(source),
+    ...runDocumentChecks(source),
+    ...validatePineScript(source).filter(d => d.checkId)
+  ];
 }
 
 const REPO_ROOT = path.join(__dirname, '..');
@@ -145,6 +152,8 @@ test('Golden corpus: validation stays within the 100ms performance budget', () =
 const {
   SEMANTIC_CHECKS,
   extractSuppressions,
+  applySuppressions,
+  runSemanticChecks,
   validatePineScript
 } = require('../packages/validator/dist/index.js');
 
@@ -167,7 +176,10 @@ test('Semantic gate: no check fires on any committed fixture', () => {
     // validator directly. Semantic checks live in the package; calling the
     // extension's modules bypasses them entirely and the gate silently passes
     // whatever it is supposed to be catching.
-    const semantic = validatePineScript(source).filter(d => d.checkId);
+    // runSemanticChecks directly, with suppressions applied exactly as the editor
+    // does — naming the source explicitly rather than relying on the aggregate, so
+    // scripts/audit.js can see this source is gated.
+    const semantic = applySuppressions(runSemanticChecks(source), extractSuppressions(source));
 
     for (const finding of semantic) {
       offenders.push(`${relativePath}:${finding.line} [${finding.checkId}] ${finding.message}`);

--- a/validate-cli.js
+++ b/validate-cli.js
@@ -34,6 +34,14 @@ function loadValidators() {
   // on files the editor covered in squiggles, so both run here by default.
   try { out.documentChecks = { validate: require('./dist/src/parser/documentChecks').runDocumentChecks }; }
   catch (e) { out.documentChecksErr = e.message; }
+  // Semantic checks — the third diagnostic source, from the published engine.
+  // ADR-0001: written once, consumed here and by the extension.
+  try {
+    const eng = require('pinescript-v6-validator');
+    out.semanticChecks = {
+      validate: (code) => eng.applySuppressions(eng.runSemanticChecks(code), eng.extractSuppressions(code))
+    };
+  } catch (e) { out.semanticChecksErr = e.message; }
   return out;
 }
 
@@ -85,6 +93,7 @@ function main() {
     console.log(`\n${paint('▸ ' + file, c.bold)}  ${paint('(' + code.split('\n').length + ' lines)', c.dim)}`);
     if (mode === 'accurate' || mode === 'both') totalErrors += printErrors('AccurateValidator', run(v.accurate, code));
     if ((mode === 'accurate' || mode === 'both') && v.documentChecks) totalErrors += printErrors('DocumentChecks', run(v.documentChecks, code));
+    if ((mode === 'accurate' || mode === 'both') && v.semanticChecks) totalErrors += printErrors('SemanticChecks', run(v.semanticChecks, code));
     if (mode === 'comprehensive' || mode === 'both') totalErrors += printErrors('ComprehensiveValidator', run(v.comprehensive, code));
   }
   console.log('');


### PR DESCRIPTION
Ships the seven semantic detectors from [SPEC.md](https://github.com/jpantsjoha/pinescript-plugin/blob/main/SPEC.md) to users.

## What users get

Diagnostics for code that **compiles and is still wrong**:

| ID | Detects | Severity |
|---|---|---|
| S1 | `request.security()` reading the current, forming bar — repainting | Warning |
| S2 | `ta.*` inside a conditional — history develops gaps | Warning |
| S5/S6 | >64 plots, >40 `request.*()` — TradingView rejects the script | Error |
| S7 | `plot`/`bgcolor` outside global scope — v6 scope error | Error |
| S8 | Function defined inside a block | Error |
| S9 | `strategy.entry` with no exit anywhere | Warning |

`// pine-ignore: S1` suppresses one you have considered. Syntactic diagnostics are never suppressible.

## Architecture — ADR-0001 enforced

Extension now consumes `pinescript-v6-validator@0.2.0`. **I started mirroring the engine sources into `src/parser/` and stopped** — that is precisely the drift this project has already been bitten by. Build copies the pinned package's output into `dist/engine/`; the package stays the single source.

## Two packaging failures caught before release

1. **The first VSIX would have died at activation.** `node_modules` is excluded, so the engine dependency was absent. Caught by extracting the archive and *executing* the packaged code — the file listing looked perfectly fine.
2. Un-ignoring `node_modules` made `vsce` walk the whole tree and hang past ten minutes.

## Verification

| | |
|---|---|
| `npm test` | **169/169** |
| Typecheck | clean |
| Audit | 18 pass · 2 warn · 0 fail |
| Sabotage | disabling each of 6 check functions fails 1–4 of its own tests |
| Packaged VSIX | extracted and executed: S1/S7 fire, clean stays clean, suppression works |
| Perf | 1.21ms full pipeline |

## Real bugs found

`examples/indicator.2.3.pine` called `bgcolor()` inside `if` — a genuine v6 scope error. One of my own corpus fixtures called `ta.highest` inside `if barstate.islast`, the exact anti-pattern S2 exists to catch.