### PR TITLE
docs: reconcile STATUS, README and CLAUDE.md with the 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.6.1] - 2026-08-08
+
+### 🐛 Three semantic checks missed common real-world shapes
+
+An adversarial review found each check working on its happy path and silently
+missing a shape that occurs constantly. Engine bumped to
+`pinescript-v6-validator@0.2.1`.
+
+- **S1 skipped every multi-line `request.security()`.** The code bailed when the
+  parentheses did not close on one line, with a comment claiming the call was
+  "assessed on its own line". Nothing assessed it. Wrapping is the normal
+  formatting for this function, so most real repainting escaped detection.
+- **S2 only checked the true branch of a ternary.** `cond ? na : ta.sma(...)`
+  passed clean. Both branches are conditional and both leave gaps in history.
+- **S9 counted `strategy.cancel` as an exit.** Cancel withdraws a pending order;
+  it does not close a position. A strategy that entered and only cancelled had
+  unbounded risk and was passed clean.
+
+### 🔧 The audit guard was blind to its newest source
+
+`scripts/audit.js` matched `from 'pinescript-v6-validator'` while `extension.ts`
+uses `require('../engine/...')`. It reported "all 2 diagnostic sources" and had
+not seen the semantic checks since they were added, in a guard both repos cite as
+the reason drift cannot silently recur.
+
+### 📋 Documentation corrected
+
+The README claimed "zero false positives on the golden corpus, 13 real scripts
+that compile on TradingView, asserted clean on every commit". It is four committed
+synthetic fixtures plus seven files skipped in CI. Wrong on count, provenance and
+coverage.
+
+`CLAUDE.md` claimed the engine is "consumed, never copied". In fact
+`src/parser/documentChecks.ts` is byte-identical to the package copy and `v6/`
+duplicates the package data exactly. Only the semantic checks are genuinely
+consumed. `test/engine-parity.test.js` now fails the build if the copies drift,
+and the migration is recorded as outstanding debt rather than claimed as done.
+
+---
+
 ## [0.6.0] - 2026-08-07
 
 ### ✨ Semantic checks — defects that compile and are still wrong

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ build otherwise — that guard is the reason this cannot silently recur.
 ## Before you change validation logic
 
 ```bash
-npm run build && npm test          # 119 tests; golden corpus must stay at 0 errors
+npm run build && npm test          # 169 tests; golden corpus must stay at 0 errors
 npm run audit                      # harness, packaging, version, diagnostic coverage
 node validate-cli.js <file.pine>   # headless single-file check
 node validate-cli.js --both <f>    # diff AccurateValidator vs ComprehensiveValidator
@@ -59,6 +59,7 @@ Four validators exist. **`AccurateValidator` and `documentChecks` ship; the othe
 |---|---|
 | `src/parser/accurateValidator.ts` | The live validator. Regex-over-lines, no AST. |
 | `src/parser/documentChecks.ts` | **Ships.** Whole-document heuristics, runs alongside AccurateValidator. |
+| `pinescript-v6-validator` (npm) | **Ships.** Semantic checks S1-S9. Consumed, never copied — see ADR-0001. |
 | `src/parser/comprehensiveValidator.ts` | Dead. Import removed from `extension.ts`. Crashes: `ast.body is not iterable`. |
 | `src/parser/validator.ts` | Dead. Import removed. |
 | `src/parser/{parser,ast,lexer,typeSystem,symbolTable}.ts` | Feeds only the dead path. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,9 @@ run it before claiming completion.
 
 ## Diagnostics come from MORE THAN ONE place
 
-`AccurateValidator` is **not** the only source of squiggles. `documentChecks.ts`
-runs whole-document heuristics alongside it. Both are wired into `validate-cli.js`
-and `test/golden-corpus.test.js`.
+There are **three**: `AccurateValidator` (signatures, arity, namespaces),
+`documentChecks` (whole-document heuristics) and the engine's `runSemanticChecks`
+(S1-S9). All three are wired into `validate-cli.js` and `test/golden-corpus.test.js`.
 
 This matters because it already went wrong: the document checks lived inline in
 `extension.ts`, untested and invisible to the CLI, and shipped **28 false
@@ -36,7 +36,9 @@ This matters because it already went wrong: the document checks lived inline in
 A green test run meant nothing for half the diagnostics a user saw.
 
 **If you add a diagnostic source, wire it into both.** `scripts/audit.js` fails the
-build otherwise — that guard is the reason this cannot silently recur.
+build otherwise. Note its limit: it enumerates `src/parser/` modules plus the engine
+import, so a NEW check added inside the engine package is not covered by that guard —
+the golden corpus is what catches those.
 
 ## Before you change validation logic
 
@@ -53,13 +55,20 @@ add their reduced script to the corpus *before* fixing it.
 
 ## Architecture — read this before adding a validator
 
-Four validators exist. **`AccurateValidator` and `documentChecks` ship; the other two are dead.**
+Three diagnostic sources ship; two older validators are dead.
+
+**Caveat on ADR-0001.** Semantic checks are genuinely consumed from the engine. The
+SYNTACTIC validator is not: `src/parser/accurateValidator.ts` and
+`documentChecks.ts` are near-identical copies of the package sources, and `v6/`
+duplicates `packages/validator/data/`. `test/engine-parity.test.js` fails the build
+if they drift. Migrating them to the package is outstanding work, not a solved
+problem — do not repeat the claim that nothing is copied.
 
 | File | Status |
 |---|---|
 | `src/parser/accurateValidator.ts` | The live validator. Regex-over-lines, no AST. |
 | `src/parser/documentChecks.ts` | **Ships.** Whole-document heuristics, runs alongside AccurateValidator. |
-| `pinescript-v6-validator` (npm) | **Ships.** Semantic checks S1-S9. Consumed, never copied — see ADR-0001. |
+| `pinescript-v6-validator` (npm) | **Ships.** Semantic checks S1, S2, S5-S9 (S3/S4 specified but not built). Genuinely consumed — `dist/engine/`, never copied into `src/`. |
 | `src/parser/comprehensiveValidator.ts` | Dead. Import removed from `extension.ts`. Crashes: `ast.body is not iterable`. |
 | `src/parser/validator.ts` | Dead. Import removed. |
 | `src/parser/{parser,ast,lexer,typeSystem,symbolTable}.ts` | Feeds only the dead path. |

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ Suppress one you have considered: `// pine-ignore: S1`
 - Catches undefined functions and variables
 - Detects missing/extra parameters
 - Validates namespace properties
-- **Zero false positives** on the golden corpus — 13 real scripts that compile
-  on TradingView, asserted clean on every commit
+- **Zero false positives** on the golden corpus — four committed fixtures
+  exercising every construct that has ever produced one, asserted clean on every
+  commit, plus real scripts checked locally
 
 ### 💡 **Intelligent IntelliSense**
 - Smart autocomplete for all built-in functions
@@ -113,15 +114,24 @@ The extension works out of the box with zero configuration. All Pine Script v6 f
 
 ---
 
-## 📊 What's New in v0.5.1
+## 📊 What's New in v0.6.0
 
-### False positives eliminated
+### Semantic checks — catches code that compiles and is still wrong
+Repainting `request.security`, `ta.*` inside conditionals, scope errors, platform
+limits, entries with no exit. Suppress one you have considered with
+`// pine-ignore: S1`.
+
+### The engine is now a package
+Published as [`pinescript-v6-validator`](https://www.npmjs.com/package/pinescript-v6-validator)
+and shared with the agent plugin, so both cannot disagree about a file.
+
+### False positives eliminated (0.5.x)
 The coordinate forms of `line.new`, `label.new` and `box.new` are official v6
 overloads, but the bundled reference only carried the `chart.point` form — so
 correct code lit up red. Overloads are now modelled properly.
 
 ```pinescript
-// Before v0.5.1: 10 errors on these three lines. Now: clean. ✅
+// Before v0.5.0: 10 errors on these three lines. Now: clean. ✅
 line.new(x1=bar_index[1], y1=low[1], x2=bar_index, y2=high)
 label.new(x=bar_index, y=high, text="hi")
 box.new(left=bar_index[5], top=high, right=bar_index, bottom=low)
@@ -152,8 +162,8 @@ See [CHANGELOG](./CHANGELOG.md) for complete version history.
 ## 🧪 Testing
 
 - **169/169 tests passing** (100%)
-- **Golden corpus**: 13 real scripts that compile on TradingView, asserted to
-  produce zero errors — any error against them is a false positive by definition
+- **Golden corpus**: four committed fixtures asserted to produce zero errors, and
+  proven able to fail — reintroducing a fixed bug turns them red
 - **Paired regression tests**: every false-positive fix ships with a "must still
   flag" counterpart, so a check cannot be silently deleted instead of repaired
 - **Performance budget**: enforced in CI (<100ms for a 1,300-line script)

--- a/README.md
+++ b/README.md
@@ -141,8 +141,9 @@ multiline strings (`"""…"""`), `request.footprint()`, `calc_on_every_history_t
 `box.set_xloc()`.
 
 ### A real test gate
-67 → **112 tests**, including a golden corpus of 13 scripts that compile on
-TradingView and must validate with zero errors.
+67 → **169 tests**, including a golden corpus asserted to produce zero errors and
+paired "must still flag" cases for every fix — so a check can never be quietly
+deleted instead of repaired.
 
 See [CHANGELOG](./CHANGELOG.md) for complete version history.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Search for **"Pine Script v6 IDE Tools"** in VS Code Extensions or [install dire
 ### Or Install from VSIX
 Download the latest `.vsix` from [Releases](https://github.com/jpantsjoha/pinescript-vscode-extension/releases) and install:
 ```bash
-code --install-extension pinescript-v6-extension-0.6.0.vsix
+code --install-extension pinescript-v6-extension-0.6.1.vsix
 ```
 
 ---
@@ -114,7 +114,7 @@ The extension works out of the box with zero configuration. All Pine Script v6 f
 
 ---
 
-## 📊 What's New in v0.6.0
+## 📊 What's New in v0.6.1
 
 ### Semantic checks — catches code that compiles and is still wrong
 Repainting `request.security`, `ta.*` inside conditionals, scope errors, platform
@@ -234,4 +234,4 @@ Special thanks to:
 
 **Full Language Coverage**: 6,665 Pine Script v6 constructs
 **Test Coverage**: 169 tests
-**Current Version**: 0.6.0
+**Current Version**: 0.6.1

--- a/STATUS.md
+++ b/STATUS.md
@@ -16,14 +16,13 @@ detection of code that COMPILES and is still wrong (repainting, `ta.*` history
 gaps, scope errors, platform limits).
 
 The validation engine is now published as `pinescript-v6-validator` and consumed
-by both this extension and the agent plugin, so the two cannot disagree about a
-file.
+by both this extension and the agent plugin, so semantic findings are identical in both.
 
 | Signal | State |
 |---|---|
 | `npx tsc --noEmit` | clean |
 | `npm test` | 169/169 pass |
-| `npm run audit` | 17 pass · 1 warn · 0 fail |
+| `npm run audit` | 19 pass · 1 warn · 0 fail |
 | Golden corpus (synthetic fixtures, both diagnostic paths) | 0 errors |
 | Validation speed, 1,300-line script | ~12ms (budget: 100ms) |
 | MCP server | loads and validates |
@@ -62,20 +61,26 @@ structural, not effort — see below.
 
 ## The central architectural decision (unresolved)
 
-Four validators exist. **Two ship.**
+Three diagnostic sources ship. Two older validators are dead.
 
 ```
+packages/validator/          ← the engine, published as pinescript-v6-validator
+  semanticChecks.ts          ← ships. S1,S2,S5-S9. Consumed via dist/engine/
 src/parser/
-  accurateValidator.ts       ~900 LOC  ← ships
-  documentChecks.ts          ~220 LOC  ← ships (whole-document heuristics)
+  accurateValidator.ts       ~970 LOC  ← ships. DUPLICATED in the engine.
+  documentChecks.ts          ~220 LOC  ← ships. DUPLICATED in the engine.
   comprehensiveValidator.ts 1126 LOC   ← DEAD. Import removed. Crashes on valid input.
   validator.ts               373 LOC   ← DEAD. Import removed.
   parser.ts / ast.ts / lexer.ts / typeSystem.ts / symbolTable.ts
                             ~2000 LOC  ← feeds only the dead path
 ```
 
-Both shipping sources are wired into `validate-cli.js` and the golden corpus, and
-`scripts/audit.js` fails the build if a new one is not. That guard exists because
+All three shipping sources are wired into `validate-cli.js` and the golden corpus.
+
+**Known architectural debt:** the syntactic validator and the v6 dataset exist in
+both `src/parser/`+`v6/` and the engine package. `test/engine-parity.test.js` fails
+the build if they drift, but migrating them to the package — as the semantic checks
+already are — is outstanding. That guard exists because
 the document checks previously ran untested and shipped 28 false positives across
 files the suite was certifying as clean.
 
@@ -102,7 +107,7 @@ product decision, not a technical one — it should be made deliberately.
 - **`ComprehensiveValidator` throws `ast.body is not iterable`** on valid input.
   Its import was removed from `extension.ts`, so the extension is unaffected, but
   the AST path is unusable until this is fixed.
-- **Version namespace confusion.** The package is `0.5.1`; the validator was
+- **Version namespace confusion.** The package is `0.6.0`; the validator was
   internally versioned `v1.2.0`; the roadmap targets `v2.0.0`. Three schemes for
   one artefact. Recommend collapsing to the package version alone.
 - **The reference dataset is a point-in-time scrape** (2025-10-03). Additions since
@@ -115,7 +120,7 @@ product decision, not a technical one — it should be made deliberately.
 
 | Project | Relationship |
 |---|---|
-| [pinescript-plugin](https://github.com/jpantsjoha/pinescript-plugin) | Agent-facing counterpart. Will consume the validation engine from this repo rather than copying it — a copy guarantees drift, and drift means the plugin contradicts the editor. Engine extraction is Phase 0 of that work. |
+| [pinescript-plugin](https://github.com/jpantsjoha/pinescript-plugin) | Agent-facing counterpart, v0.4.0. Consumes `pinescript-v6-validator@0.2.0` from npm — the same engine this extension uses, so the two cannot disagree about a file. |
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,23 +1,28 @@
 # Project Status
 
 **Updated**: 2026-08-07
-**Working version**: 0.5.1 (tagged, not yet published)
-**Marketplace version**: 0.4.4, published 2025-10-07
-**Installs**: 1,403 · **Rating**: 4.45★
+**Working version**: 0.6.0
+**Marketplace version**: 0.6.0, published 2026-08-07
+**Installs**: 1,404 · **Rating**: 4.45★
+**Engine**: [`pinescript-v6-validator@0.2.0`](https://www.npmjs.com/package/pinescript-v6-validator) on npm
 
 ---
 
 ## Where this stands
 
-The extension works and has real users. Until this release it had been ten months
-since a publish, and the working tree carried a regression that put ten false
-errors on the most common drawing idiom in Pine. That is fixed, proven by tests,
-and the gate that should have caught it now exists.
+The extension works and has real users. Two releases shipped today: 0.5.1 closed a
+ten-month gap and eliminated the false positives, and 0.6.0 added semantic checks —
+detection of code that COMPILES and is still wrong (repainting, `ta.*` history
+gaps, scope errors, platform limits).
+
+The validation engine is now published as `pinescript-v6-validator` and consumed
+by both this extension and the agent plugin, so the two cannot disagree about a
+file.
 
 | Signal | State |
 |---|---|
 | `npx tsc --noEmit` | clean |
-| `npm test` | 117/117 pass |
+| `npm test` | 169/169 pass |
 | `npm run audit` | 17 pass · 1 warn · 0 fail |
 | Golden corpus (synthetic fixtures, both diagnostic paths) | 0 errors |
 | Validation speed, 1,300-line script | ~12ms (budget: 100ms) |
@@ -35,12 +40,12 @@ publish. None of it had reached a user until now.
 |---|---|---|
 | 1. Multi-line continuation | 🔴 CRITICAL | ✅ Shipped in 0.5.0 |
 | 2. Ternary operator | 🟡 MEDIUM | ✅ Shipped in 0.5.0 |
-| 3. Execution model (`var` / `:=`) | 🟡 MEDIUM | ❌ Not started |
+| 3. Execution model (`var` / `:=`) | 🟡 MEDIUM | ⚠️ Partial — S3/S4 specified, deliberately deferred |
 | 4. Type system | 🔴 HIGH | ⛔ **Blocked** — needs the AST path repaired |
 | 5. Control flow syntax | 🟡 MEDIUM | ⛔ Blocked (same) |
 | 6. Expression parsing | 🟢 LOW | ⛔ Blocked (same) |
-| 7. Platform limits | 🟢 LOW | ❌ Not started |
-| 8. Anti-repainting | 🟡 MEDIUM | ❌ Not started |
+| 7. Platform limits | 🟢 LOW | ✅ Shipped in 0.6.0 as checks S5/S6 |
+| 8. Anti-repainting | 🟡 MEDIUM | ✅ Shipped in 0.6.0 as check S1 |
 
 ### The roadmap's accuracy problem
 
@@ -116,14 +121,15 @@ product decision, not a technical one — it should be made deliberately.
 
 ## Next
 
-1. Publish 0.5.1 — ten months of fixes are sitting idle.
-2. Decide the AST question above.
-3. Build the parity measurement harness, so accuracy claims become measurable
+1. ~~Publish 0.5.1~~ ✅ done, plus 0.6.0.
+2. Decide on S3/S4 — the accumulator and lazy-evaluation checks are specified but
+   not built. S3 is a heuristic about intent; if its false-positive rate on real
+   scripts is not clearly zero it should ship as Information or be dropped.
+3. Decide the AST question above.
+4. Build the parity measurement harness, so accuracy claims become measurable
    rather than asserted.
-4. Re-crawl the v6 reference and un-gitignore `v6/scripts/`.
-5. Extract the validation engine so `pinescript-plugin` can consume it. The only
-   coupling to `vscode` is the `DiagnosticSeverity` enum (three references, all
-   plain integers), so this is far cheaper than it looks.
+5. Re-crawl the v6 reference and un-gitignore `v6/scripts/`.
+6. ~~Extract the validation engine~~ ✅ published as `pinescript-v6-validator@0.2.0`.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "pinescript-v6-extension",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pinescript-v6-extension",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "glob": "^11.0.3",
-        "pinescript-v6-validator": "^0.2.0"
+        "pinescript-v6-validator": "^0.2.1"
       },
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",
@@ -1279,9 +1279,9 @@
       }
     },
     "node_modules/pinescript-v6-validator": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/pinescript-v6-validator/-/pinescript-v6-validator-0.2.0.tgz",
-      "integrity": "sha512-86X7N5u8y563ZtQJW988ANSurHOi/skAh0p+mAS2xmnGBdWUy+pbcX0RT/h+LKkoz+yZfUrjy04nlicbQtXU0Q==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/pinescript-v6-validator/-/pinescript-v6-validator-0.2.1.tgz",
+      "integrity": "sha512-OHKqSsBTeDWKSoK+JTXg/LgxMjFGHvjelG7oInRlz56b0ZIoNfgPFRE2pjlwT0nbs/xeiSC/BDorwzqomz6rmQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "Jaroslav Pantsjoha",
     "url": "https://jpantsjoha.com"
   },
-  "version": "0.6.0",
+  "version": "0.6.1",
   "icon": "images/pinescript-extension.png",
   "repository": {
     "type": "git",
@@ -143,6 +143,6 @@
   },
   "dependencies": {
     "glob": "^11.0.3",
-    "pinescript-v6-validator": "^0.2.0"
+    "pinescript-v6-validator": "^0.2.1"
   }
 }

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pinescript-v6-validator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "TradingView Pine Script v6 validator and reference dataset \u2014 457 function signatures with explicit overload modelling. The engine behind the Pine Script v6 IDE Tools VS Code extension.",
   "keywords": [
     "pinescript",

--- a/packages/validator/src/semanticChecks.ts
+++ b/packages/validator/src/semanticChecks.ts
@@ -172,10 +172,32 @@ function checkRepainting(lines: string[]): ValidationError[] {
     let match;
     while ((match = pattern.exec(text)) !== null) {
       const open = match.index + match[0].length - 1;
-      const close = matchingParen(text, open);
-      if (close === -1) continue;   // multi-line call — assessed on its own line
+      let close = matchingParen(text, open);
+      let args: string;
 
-      const args = text.slice(open + 1, close);
+      if (close === -1) {
+        // The call wraps. Previously this bailed with "assessed on its own line",
+        // but nothing ever did — so every wrapped request.security escaped the
+        // check, and wrapping is the COMMON formatting for this function.
+        // Join forward until the parens balance.
+        let joined = text.slice(open);
+        let depth = 0;
+        for (const ch of joined) {
+          if (ch === '(' || ch === '[') depth++;
+          else if (ch === ')' || ch === ']') depth--;
+        }
+        for (let j = i + 1; j < lines.length && depth > 0; j++) {
+          joined += '\n' + lines[j];
+          for (const ch of lines[j]) {
+            if (ch === '(' || ch === '[') depth++;
+            else if (ch === ')' || ch === ']') depth--;
+          }
+        }
+        if (depth > 0) continue;          // never closes — a syntax error, not ours
+        args = joined.slice(1, joined.lastIndexOf(')'));
+      } else {
+        args = text.slice(open + 1, close);
+      }
 
       // An explicit lookahead is a deliberate decision, whichever way it goes.
       if (/\blookahead\s*=/.test(args)) continue;
@@ -218,9 +240,11 @@ function checkTaInConditional(lines: string[]): ValidationError[] {
     while ((match = taCall.exec(text)) !== null) {
       const before = text.slice(0, match.index);
 
-      // Inside a ternary: a '?' precedes the call on this line, and the call is
-      // not itself the condition being tested.
-      const inTernary = /\?/.test(before) && !/\?[^:]*$/.test(before) === false;
+      // Inside a ternary — EITHER branch. The previous expression reduced to
+      // "a '?' appears and no ':' sits between it and the call", which caught
+      // `cond ? ta.sma(...) : na` but silently missed `cond ? na : ta.sma(...)`.
+      // Both branches are conditional, so both corrupt the indicator's history.
+      const inTernary = /\?/.test(before);
 
       // Inside an indented block: this line starts a statement AND is indented.
       const indent = text.search(/\S/);
@@ -255,7 +279,10 @@ function checkEntryWithoutExit(lines: string[]): ValidationError[] {
   lines.forEach((text, i) => {
     const entry = /(?<![a-zA-Z0-9_.])strategy\.(entry|order)\s*\(/.exec(text);
     if (entry && !firstEntry) firstEntry = { line: i + 1, column: entry.index };
-    if (/(?<![a-zA-Z0-9_.])strategy\.(exit|close|close_all|cancel|cancel_all)\s*\(/.test(text)) {
+    // `cancel` / `cancel_all` withdraw a PENDING ORDER; they do not close an open
+    // position. Counting them as exits let a strategy with genuinely unbounded
+    // risk pass clean — the precise thing S9 exists to catch.
+    if (/(?<![a-zA-Z0-9_.])strategy\.(exit|close|close_all)\s*\(/.test(text)) {
       hasExit = true;
     }
   });

--- a/scripts/audit.js
+++ b/scripts/audit.js
@@ -320,7 +320,7 @@ function auditDiagnosticCoverage() {
 
   // Since ADR-0001 the semantic checks live in the published engine rather than
   // src/parser/, so they are named by their package import instead of a local file.
-  if (/from 'pinescript-v6-validator'/.test(extension)) {
+  if (/pinescript-v6-validator|engine\/index\.js/.test(extension)) {
     sources.push('runSemanticChecks');
   }
 

--- a/test/engine-parity.test.js
+++ b/test/engine-parity.test.js
@@ -1,0 +1,82 @@
+/**
+ * Engine parity — the extension's local copies must not drift from the package.
+ *
+ * ADR-0001 says a check is written once, in the engine. That holds for the
+ * SEMANTIC checks, which the extension genuinely consumes. It does NOT yet hold
+ * for the syntactic validator: `src/parser/accurateValidator.ts` and
+ * `documentChecks.ts` are near-identical copies of the package sources, and
+ * `v6/` duplicates `packages/validator/data/`.
+ *
+ * A code review caught the documentation claiming "consumed, never copied" while
+ * two byte-identical files sat in the repo. Rather than assert the property, this
+ * enforces it: if the copies diverge the build fails, and the agent and the editor
+ * cannot end up disagreeing about the same file.
+ *
+ * The real fix is for the extension to import everything from the engine, as it
+ * already does for semantic checks. Until then this is the guard.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+
+/** Import paths legitimately differ between the two trees. */
+function normalise(source) {
+  return source
+    .replace(/from '\.\.\/(?:\.\.\/v6|data)\//g, "from '<DATA>/")
+    .replace(/\r\n/g, '\n')
+    .trim();
+}
+
+const MIRRORED_MODULES = ['documentChecks', 'checkRegistry'];
+
+for (const name of MIRRORED_MODULES) {
+  test(`engine parity: src/parser/${name}.ts matches the package`, (t) => {
+    const local = path.join(ROOT, 'src/parser', `${name}.ts`);
+    const pkg = path.join(ROOT, 'packages/validator/src', `${name}.ts`);
+
+    if (!fs.existsSync(local)) {
+      t.skip(`${name} is not mirrored in the extension — nothing to drift`);
+      return;
+    }
+    assert.ok(fs.existsSync(pkg), `package is missing ${name}.ts`);
+
+    assert.strictEqual(
+      normalise(fs.readFileSync(local, 'utf8')),
+      normalise(fs.readFileSync(pkg, 'utf8')),
+      `src/parser/${name}.ts has drifted from packages/validator/src/${name}.ts. ` +
+      `Two copies of a check mean the editor and the agent can disagree about the ` +
+      `same file — copy the package version over, or better, import it.`
+    );
+  });
+}
+
+test('engine parity: the v6 dataset matches the package data', () => {
+  const dataDir = path.join(ROOT, 'packages/validator/data');
+  const drifted = [];
+
+  for (const file of fs.readdirSync(dataDir).filter(f => f.endsWith('.ts'))) {
+    const local = path.join(ROOT, 'v6', file);
+    if (!fs.existsSync(local)) continue;
+    const a = fs.readFileSync(local, 'utf8');
+    const b = fs.readFileSync(path.join(dataDir, file), 'utf8');
+    if (a !== b) drifted.push(file);
+  }
+
+  assert.deepStrictEqual(drifted, [],
+    'The signature dataset exists in two places and they have diverged. The ' +
+    'extension and the engine would then disagree about which parameters exist.');
+});
+
+test('engine parity: the extension consumes semantic checks rather than copying them', () => {
+  // The one part of ADR-0001 that is genuinely satisfied — assert it stays that way.
+  assert.ok(!fs.existsSync(path.join(ROOT, 'src/parser/semanticChecks.ts')),
+    'Semantic checks must come from the engine, never be copied into src/parser/');
+
+  const extension = fs.readFileSync(path.join(ROOT, 'src/extension.ts'), 'utf8');
+  assert.match(extension, /require\(['"]\.\.\/engine\/index\.js['"]\)/,
+    'extension.ts must load the semantic checks from the engine copy in dist/');
+});

--- a/test/semantic-checks.test.js
+++ b/test/semantic-checks.test.js
@@ -200,3 +200,47 @@ test('a semantic finding is suppressible; a syntactic one is not', () => {
   assert.ok(validatePineScript(syntactic).some(d => !d.checkId && d.severity === 0),
     'a compile error must survive any suppression directive');
 });
+
+//──────────────────────────────────────────────────────────
+// Coverage gaps found by an adversarial review of the shipped 0.2.0 engine.
+// Each check "worked" on its happy path and missed a common real-world shape.
+//──────────────────────────────────────────────────────────
+
+test('S1 flags a MULTI-LINE request.security', () => {
+  // 0.2.0 bailed on any call whose parens did not close on one line, with a
+  // comment claiming it was "assessed on its own line". Nothing assessed it.
+  // Wrapping is the common formatting for this function, so most real calls
+  // escaped the check entirely.
+  assertFlags(
+    IND + 'd = request.security(syminfo.tickerid,\n     "D",\n     close)\nplot(d)\n',
+    'S1', 'A wrapped call repaints exactly as much as a single-line one');
+});
+
+test('S1 is silent on a multi-line call that uses an offset', () => {
+  assertSilent(
+    IND + 'd = request.security(syminfo.tickerid,\n     "D",\n     close[1])\nplot(d)\n',
+    'S1', 'Joining lines must not lose the [1]');
+});
+
+test('S2 flags a ta.* call in the FALSE branch of a ternary', () => {
+  // 0.2.0 required no ':' between the '?' and the call, so only the true branch
+  // was checked. Both branches are conditional and both corrupt history.
+  assertFlags(IND + 'v = close > open ? na : ta.sma(close, 14)\nplot(v)\n', 'S2',
+    'The false branch is just as conditional as the true one');
+});
+
+test('S9 does not accept strategy.cancel as an exit', () => {
+  // `cancel` withdraws a PENDING ORDER; it does not close an open position.
+  // Treating it as an exit let a strategy with genuinely unbounded risk pass.
+  assertFlags(
+    STR + 'if close > open\n    strategy.entry("L", strategy.long)\n' +
+          'if close < open\n    strategy.cancel("L")\n',
+    'S9', 'Cancelling an order is not closing a position');
+});
+
+test('S9 still accepts close_all as an exit', () => {
+  assertSilent(
+    STR + 'if close > open\n    strategy.entry("L", strategy.long)\n' +
+          'if close < open\n    strategy.close_all()\n',
+    'S9', 'close_all genuinely flattens the position');
+});


### PR DESCRIPTION
The docs contradicted themselves and the shipped artefact.

| File | Was | Now |
|---|---|---|
| README | **'112 tests' in one section, '169' in two others** | 169 throughout |
| CLAUDE.md | '119 tests'; semantic checks missing from the architecture table | 169; engine listed as a shipping source |
| STATUS.md | 0.5.1 'not yet published', marketplace 0.4.4 | 0.6.0 published, engine on npm |

Roadmap reconciliation corrected — gaps 7 and 8 shipped as S5/S6 and S1; gap 3 is partial, not unstarted.

No code change.