### PR TITLE
S3 accumulator lifetime, S2 false-positive fix, and a regression harness for the published artefact

### DIFF
--- a/.claude/skills/validator-gate/SKILL.md
+++ b/.claude/skills/validator-gate/SKILL.md
@@ -10,11 +10,11 @@ Prove a change to this validator is correct before it leaves the machine.
 ## Run this
 
 ```bash
-npm test                       # 276 tests, ~5s — includes the packed-tarball run
-node validate-cli.js examples/*.pine
+npm test        # ~5s. Includes the packed-tarball corpus and every file in examples/.
+npm run audit   # packaging, versions, diagnostic coverage, lockfile drift
 ```
 
-That is the gate. Everything below is about reading the result honestly.
+The pre-commit hook runs both. Everything below is about reading the result honestly.
 
 For a tight edit loop, `npm run test:fast` skips the pack-and-install step. **Never
 use it as the final check**, and never before a release — see below.
@@ -25,7 +25,18 @@ use it as the final check**, and never before a release — see below.
 | `npm run test:fast` | Same, minus the packed-tarball run. Edit loop only. |
 | `npm run test:regression` | The corpus against the local build |
 | `npm run test:package` | Pack → install → corpus against the published artefact |
-| `npm run lint` | typecheck + `scripts/audit.js` single-source guard |
+| `npm run lint` | typecheck + `scripts/audit.js` |
+| `npm run audit` | packaging, version consistency, diagnostic coverage, lockfile drift |
+
+## The lockfile is a CI tripwire, not a formality
+
+CI installs with `npm ci`, which **refuses to run** when `package-lock.json`
+disagrees with `package.json`. A version bump or changed dependency range that
+forgets the lockfile passes everything locally — `node_modules` is already
+populated — then breaks every CI job at the install step, before a single test runs.
+
+It had drifted silently by two releases before `npm run audit` learned to check it.
+After any version bump or dependency change: `npm install`, and commit the lockfile.
 
 ## Why the packed-tarball run is the one that matters
 

--- a/.claude/skills/validator-gate/SKILL.md
+++ b/.claude/skills/validator-gate/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: validator-gate
+description: Run the full validation gate for the Pine Script validator before committing, releasing, or claiming a change works — typecheck, the regression corpus against both the local build and the packed npm tarball, and every file in examples/. Use after any change to packages/validator/, src/parser/, v6/ data, or the semantic checks, and before publishing the engine, packaging a VSIX, or reporting that a fix is done.
+---
+
+# validator-gate
+
+Prove a change to this validator is correct before it leaves the machine.
+
+## Run this
+
+```bash
+npm test                       # 276 tests, ~5s — includes the packed-tarball run
+node validate-cli.js examples/*.pine
+```
+
+That is the gate. Everything below is about reading the result honestly.
+
+For a tight edit loop, `npm run test:fast` skips the pack-and-install step. **Never
+use it as the final check**, and never before a release — see below.
+
+| Command | What it covers |
+|---|---|
+| `npm test` | Everything. The pre-commit hook runs this. |
+| `npm run test:fast` | Same, minus the packed-tarball run. Edit loop only. |
+| `npm run test:regression` | The corpus against the local build |
+| `npm run test:package` | Pack → install → corpus against the published artefact |
+| `npm run lint` | typecheck + `scripts/audit.js` single-source guard |
+
+## Why the packed-tarball run is the one that matters
+
+Every recurring failure in this project has had one shape: **correct in `src/`,
+broken in what users receive.**
+
+- Doc anchors that resolved against the source registry and were dead in the shipped
+  package, because the package had not been rebuilt.
+- A VSIX that died at activation because the engine was excluded from the bundle.
+- A local scratchpad path that leaked into a dependency range during testing, which
+  would have made `npm install` fail for everyone.
+- An MCP manifest declaring a server file that did not exist — and passed schema
+  validation cleanly.
+
+`test/npm-package.test.js` packs the tarball, installs it into a throwaway project,
+and drives the corpus through `require('pinescript-v6-validator')` with no path back
+into this repo. It is the only suite that can see any of the above.
+
+## The regression corpus
+
+`test/regression-corpus.js` is **data, not tests** — one table, executed against both
+the local build and the installed package, so the two cannot drift.
+
+Every entry is a defect that reached a user or survived a review. Each carries the
+date it was found and an account of how it escaped.
+
+**When you find a defect, add the case BEFORE fixing it.** Watch it fail, then fix
+it. A case added afterwards proves only that the code does what it currently does.
+
+Two rules the corpus enforces on itself:
+
+- Every case needs a real `found` date and a `why` longer than a line. A case nobody
+  understands is a case somebody deletes.
+- At least 30% of cases must assert **silence** on correct code. If negatives fall
+  away, the corpus has quietly become a "find more bugs" suite and stopped defending
+  working code, which is the harder and more valuable half.
+
+## Reading the result
+
+**A clean run is not proof the script is correct.** State what was actually checked.
+
+Warnings in `examples/` are expected — those files legitimately demonstrate `S1` on
+higher-timeframe data. **Errors are not.** An example that cannot compile teaches
+whatever it contains; that is exactly how the accumulator defect propagated.
+
+A new **false positive** is more serious than a new miss, and is a release blocker.
+It fires on working code and teaches people to ignore the tool. If a check starts
+warning on something a user wrote and TradingView accepts, fix the check — do not
+document the exception.
+
+## Before releasing
+
+Order matters. The extension bundles the engine at build time, so an extension
+pinned ahead of what is published produces a VSIX whose engine cannot be installed —
+discovered at activation, on a user's machine.
+
+1. `npm test` — all green, no skips other than the one known skip
+2. Bump and publish **the engine** (`packages/validator`) first
+3. Bump the extension, pin the new engine version, rebuild, package
+4. In `jpantsjoha/pinescript-plugin`: `make gate`, which includes `make anchors` —
+   it resolves every check's `docAnchor` against real skill headings, using the
+   **installed** engine, so it will fail until step 2 has actually landed on npm
+5. Verify the VSIX contains `dist/engine/`
+
+## When a check changes
+
+A check is written **once, in the engine** (ADR-0001). Never in a skill, never in the
+extension. A skill may *explain* a check; it must not reimplement one. `scripts/audit.js`
+guards this — if it reports fewer sources than exist, the guard has gone blind and is
+worth more attention than the thing it was checking.
+
+Every check ships with **both directions**: one case it must flag, one legitimate case
+it must stay silent on. If the "must not flag" case cannot be written, the check does
+not ship.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -43,6 +43,22 @@ fail() {
 printf '%b\n' "${BOLD}==> Type check${OFF}"
 npm run --silent typecheck || fail "typecheck failed"
 
+printf '%b\n' "${BOLD}==> Repo self-audit${OFF}"
+# Catches what tests cannot: npm scripts pointing at deleted files, the VSIX
+# shipping source or omitting runtime data, a diagnostic source wired into the
+# extension but not the CLI, and lockfile drift.
+#
+# Lockfile drift is the one worth naming. CI installs with `npm ci`, which REFUSES
+# to run when package-lock.json disagrees with package.json. A version bump that
+# forgets the lockfile passes every test locally — node_modules is already
+# populated — and then breaks every CI job at the install step, before a single
+# test runs. It had drifted silently by two releases.
+AUDIT="$(npm run --silent audit 2>&1)" || {
+  printf '%s\n' "$AUDIT" | grep -E "FAIL" | head -10
+  fail "self-audit failed — run: npm run audit"
+}
+printf '%s\n' "$AUDIT" | tail -1
+
 printf '%b\n' "${BOLD}==> Test suite (published-package corpus + examples/)${OFF}"
 # Deliberately NOT SKIP_PACKAGE_TEST. The pack-and-install run is the one that
 # catches source/artefact drift, which is the class of defect that reaches users.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Blocks a commit that breaks the validator.
+#
+# Install with:  npm run hooks:install
+# Bypass with:   git commit --no-verify   (deliberately, and say why in the message)
+#
+# WHAT THIS GUARDS, AND WHY IT IS WORTH THE SECONDS
+#
+# This project's characteristic failure is a check that is correct in src/ and wrong
+# in the artefact users receive, or a check that passes because it is asserting
+# nothing. Both have shipped. So the gate runs the full suite — including the
+# published-package suite, which packs the tarball, installs it into a throwaway
+# project, and drives the regression corpus through `require('pinescript-v6-validator')`
+# with no path back into this repo.
+#
+# The whole thing costs about five seconds. A false positive released to users costs
+# considerably more, because it teaches them to ignore the tool.
+#
+# It also validates every file in examples/, which is where the accumulator defect
+# was found — by a person reading a file the tool had just called clean.
+
+set -uo pipefail
+
+BOLD=$'\033[1m'; RED=$'\033[31m'; GRN=$'\033[32m'; DIM=$'\033[2m'; OFF=$'\033[0m'
+
+REPO_ROOT="$(git rev-parse --show-toplevel)" || exit 0
+cd "$REPO_ROOT" || exit 0
+
+# Nothing staged that can affect behaviour? Don't tax a docs-only commit.
+STAGED="$(git diff --cached --name-only --diff-filter=ACM)"
+if ! printf '%s\n' "$STAGED" | grep -qE '\.(ts|js|json|pine)$'; then
+  printf '%b\n' "${DIM}pre-commit: no code staged, skipping the validator gate${OFF}"
+  exit 0
+fi
+
+fail() {
+  printf '\n%b\n' "${RED}${BOLD}pre-commit: $1${OFF}"
+  printf '%b\n\n' "${DIM}Fix it, or commit with --no-verify and explain why.${OFF}"
+  exit 1
+}
+
+printf '%b\n' "${BOLD}==> Type check${OFF}"
+npm run --silent typecheck || fail "typecheck failed"
+
+printf '%b\n' "${BOLD}==> Test suite (published-package corpus + examples/)${OFF}"
+# Deliberately NOT SKIP_PACKAGE_TEST. The pack-and-install run is the one that
+# catches source/artefact drift, which is the class of defect that reaches users.
+#
+# examples/ is covered by test/examples.test.js rather than a second pass here. An
+# earlier version of this hook ran validate-cli.js over the whole directory and
+# blocked every commit, because two files are DELIBERATE negative fixtures. The test
+# knows the difference — it reads the `// pine-expect: invalid` marker, and asserts
+# the marked files still fail so the marker cannot hide a regression. Bash did not,
+# and could not without duplicating that logic.
+OUTPUT="$(npm test --silent 2>&1)" || {
+  printf '%s\n' "$OUTPUT" | grep -E "✖|not ok|AssertionError|Expected" | head -20
+  fail "tests failed — run: npm test"
+}
+printf '%s\n' "$OUTPUT" | grep -E "^ℹ (tests|pass|fail|skipped)"
+
+printf '\n%b\n\n' "${GRN}${BOLD}pre-commit: validator gate passed${OFF}"

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,11 @@ examples/
 
 # npm pack output
 packages/*/*.tgz
+
+# Credentials — never commit. `npm install ./x.tgz`, `npm config set` and `npm login`
+# can all write a repo-local .npmrc containing an auth token, which is how a publish
+# credential ends up in a public repo by accident. Global config lives in ~/.npmrc.
+.npmrc
+.env
+.env.*
+!.env.example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,36 @@ constant and built-in-variable *names* are never checked (`shape.trianglup` vali
 clean), re-declaring with `=` is not caught, and `ta.*` on the right of `and`/`or`
 escapes S2 because v6 short-circuits.
 
+### 🧪 A regression harness aimed at the published artefact
+
+Every recurring failure in this project has had one shape: correct in `src/`, broken
+in what users receive. Dead doc anchors that resolved against the source and not the
+shipped package. A VSIX whose engine was excluded from the bundle. A scratchpad path
+that leaked into a dependency range mid-session and was caught by eye, not by a gate.
+No suite importing from `packages/validator/dist` can see any of those.
+
+- **`test/regression-corpus.js`** — every defect this validator has ever shipped, as
+  data rather than tests. Each entry carries the date it was found and an account of
+  how it escaped.
+- **`test/npm-package.test.js`** — packs the tarball, installs it into a throwaway
+  project, and drives the same corpus through `require('pinescript-v6-validator')`
+  with no path back into this repo. Also asserts no manifest pins a local path, and
+  that the extension never pins an engine version ahead of what is published.
+
+One table, two environments, so source and published cannot drift. The corpus polices
+itself: every case needs a real date and a reason, and at least 30% must assert
+*silence* on correct code — otherwise it quietly becomes a "find more bugs" suite and
+stops defending working code.
+
+Verified by reintroducing the S2 false positive and confirming both suites fail by
+name, and by staging it and confirming the pre-commit hook refuses the commit.
+
+- **`.githooks/pre-commit`** — typecheck, the full suite including the packed-tarball
+  run, and every file in `examples/`. About five seconds. Chains from the machine-wide
+  secret scanner rather than replacing it. Install with `npm run hooks:install`.
+- **`.claude/skills/validator-gate`** — the release order, how to read a clean run
+  honestly, and why a new false positive is a release blocker where a new miss is not.
+
 ### 🔧 `make gate` could pass with its main check disabled
 
 `validate_skill_examples.py` returned 0 when the engine was absent, so a local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.6.2] - 2026-08-08
+
+### ✨ S3 — accumulator lifetime, found in the field
+
+A user validated `examples/test-v6-features.pine`, got a clean-ish report, and then
+spotted by eye what the tool had missed:
+
+```pine
+var float sum = 0.0
+for i = 0 to 9
+    sum := sum + close[i]
+```
+
+`var` persists across bars, so this adds ten more closes on every bar for the life of
+the chart. The author wanted "sum of the last ten closes". A second instance in the
+same file was quieter still — `var int counter = 0` guarding a `while counter < 5`
+loop that, on bar two, can never run again.
+
+The original spec had only the **opposite** shape: an accumulator *missing* `var`,
+which resets each bar. That is the cheaper half — it produces a visibly constant
+series. This half produces a plausible number that drifts, which is the defect that
+survives a backtest.
+
+Now detected as **S3** (warning) in `pinescript-v6-validator@0.3.0`, with two
+exemptions that keep it quiet on correct code: a reset before the loop (a `var`
+reused as a buffer) and a run-once guard (`barstate.isfirst`, `bar_index == 0`) for
+table-building on the first bar. Seven paired tests; fires twice across 24 committed
+`.pine` files and both are real defects.
+
+### 🐛 Four of nine documentation anchors pointed at nothing
+
+Every semantic finding carries a `docAnchor` linking to the prose that explains it.
+The engine owned the anchor, the plugin repo owned the heading, and nothing made them
+agree — so when headings were reworded the links rotted, including **S1's**, the
+most-cited defect in Pine Script.
+
+The test meant to prevent this asserted `docAnchor.includes('#')`, which all four
+dead links passed. Shape is not resolution. Anchors are now resolved against the real
+skill headings by `make anchors` in the plugin repo, and the S8 anchor points at a
+compile-error table that now actually documents S7 and S8.
+
+### 📝 The accumulator guidance was the inverse of the bug
+
+The skills told readers to "declare accumulators `var` so they persist" — precisely
+the advice that produces the defect above. Run the old checklist against the reported
+bug and every item ticks. That guidance now covers both directions, and no skill
+previously mentioned `for` or `while` at all.
+
+Also corrected: three honest omissions added to "What the validator CANNOT see" —
+constant and built-in-variable *names* are never checked (`shape.trianglup` validates
+clean), re-declaring with `=` is not caught, and `ta.*` on the right of `and`/`or`
+escapes S2 because v6 short-circuits.
+
+### 🔧 `make gate` could pass with its main check disabled
+
+`validate_skill_examples.py` returned 0 when the engine was absent, so a local
+`make gate` printed "Gate passed" over zero validated examples. It now fails unless
+`--allow-skip` is passed deliberately. The same run also revealed that the five
+scaffolds advertised as "validated in CI" were opened by no script at all — true by
+luck, not by enforcement. They are now validated as whole files: 31 examples checked,
+5 of them scaffolds.
+
+---
+
 ## [0.6.1] - 2026-08-08
 
 ### 🐛 Three semantic checks missed common real-world shapes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ problem — do not repeat the claim that nothing is copied.
 |---|---|
 | `src/parser/accurateValidator.ts` | The live validator. Regex-over-lines, no AST. |
 | `src/parser/documentChecks.ts` | **Ships.** Whole-document heuristics, runs alongside AccurateValidator. |
-| `pinescript-v6-validator` (npm) | **Ships.** Semantic checks S1, S2, S5-S9 (S3/S4 specified but not built). Genuinely consumed — `dist/engine/`, never copied into `src/`. |
+| `pinescript-v6-validator` (npm) | **Ships.** Semantic checks S1, S2, S3, S5-S9 (only S4 specified but not built). Genuinely consumed — `dist/engine/`, never copied into `src/`. |
 | `src/parser/comprehensiveValidator.ts` | Dead. Import removed from `extension.ts`. Crashes: `ast.body is not iterable`. |
 | `src/parser/validator.ts` | Dead. Import removed. |
 | `src/parser/{parser,ast,lexer,typeSystem,symbolTable}.ts` | Feeds only the dead path. |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ code --install-extension pinescript-v6-extension-0.6.1.vsix
 ### 🧠 **Semantic checks — catches code that compiles and is still wrong**
 - **Repainting** — `request.security()` reading the current, forming bar
 - **`ta.*` in a conditional** — silently corrupts the indicator's own history
+- **Accumulator lifetime** — a `var` total a loop re-adds to every bar and never resets, so it grows for the life of the chart
 - **Scope errors** — `plot`/`bgcolor` inside `if`, functions defined in a block
 - **Platform limits** — 64 plots, 40 `request.*()` calls, counted before TradingView rejects you
 - **Unbounded risk** — `strategy.entry` with no exit anywhere

--- a/STATUS.md
+++ b/STATUS.md
@@ -65,7 +65,7 @@ Three diagnostic sources ship. Two older validators are dead.
 
 ```
 packages/validator/          ← the engine, published as pinescript-v6-validator
-  semanticChecks.ts          ← ships. S1,S2,S5-S9. Consumed via dist/engine/
+  semanticChecks.ts          ← ships. S1,S2,S3,S5-S9. Consumed via dist/engine/
 src/parser/
   accurateValidator.ts       ~970 LOC  ← ships. DUPLICATED in the engine.
   documentChecks.ts          ~220 LOC  ← ships. DUPLICATED in the engine.

--- a/examples/test-plot-parsing.pine
+++ b/examples/test-plot-parsing.pine
@@ -1,4 +1,7 @@
 //@version=6
+// pine-expect: invalid
+// NEGATIVE fixture: contains a plot() inside an if block (S7) on purpose, to
+// prove scope detection works. test/examples.test.js asserts it still errors.
 indicator("Test Plot Parsing")
 
 // Variable declarations

--- a/examples/test-v6-features.pine
+++ b/examples/test-v6-features.pine
@@ -218,13 +218,14 @@ priceAction = switch
     close < open => "Bearish"
     => "Neutral"
 
-// For loops
-var float sum = 0.0
+// For loops — a per-bar total must NOT be `var`, or it accumulates forever (S3)
+float sum = 0.0
 for i = 0 to 9
-    sum := sum + close[i]
+    sum += close[i]
 
-// While loops
-var int counter = 0
+// While loops — the counter is per-bar too; with `var` it would already be at the
+// limit on bar 2 and the loop would never run again (S3)
+int counter = 0
 while counter < 5
     counter += 1
 

--- a/examples/test-validation.pine
+++ b/examples/test-validation.pine
@@ -1,4 +1,9 @@
 //@version=6
+// pine-expect: invalid
+// This is a NEGATIVE fixture. It deliberately calls undefined functions so the
+// validator can be proven to catch them. test/examples.test.js asserts it still
+// produces errors — the marker excuses it from the clean sweep, it does not
+// exempt it from being checked.
 indicator("Validation Test")
 
 // ===== VALID CODE (should have NO errors) =====

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "pinescript-v6-extension",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pinescript-v6-extension",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "glob": "^11.0.3",
-        "pinescript-v6-validator": "^0.2.1"
+        "pinescript-v6-validator": "^0.3.0"
       },
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",
@@ -1279,9 +1279,9 @@
       }
     },
     "node_modules/pinescript-v6-validator": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/pinescript-v6-validator/-/pinescript-v6-validator-0.2.1.tgz",
-      "integrity": "sha512-OHKqSsBTeDWKSoK+JTXg/LgxMjFGHvjelG7oInRlz56b0ZIoNfgPFRE2pjlwT0nbs/xeiSC/BDorwzqomz6rmQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/pinescript-v6-validator/-/pinescript-v6-validator-0.3.0.tgz",
+      "integrity": "sha512-PIWr86jNnZDRkPdY/6gQEY9nwuvt6GiyF17ZObaVX+q6kmMOit7Q8oE5FDWpuIQcqXLT0j3LXrPtRYl9ifJc9Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "Jaroslav Pantsjoha",
     "url": "https://jpantsjoha.com"
   },
-  "version": "0.6.1",
+  "version": "0.6.2",
   "icon": "images/pinescript-extension.png",
   "repository": {
     "type": "git",
@@ -143,6 +143,6 @@
   },
   "dependencies": {
     "glob": "^11.0.3",
-    "pinescript-v6-validator": "^0.2.1"
+    "pinescript-v6-validator": "^0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -131,7 +131,11 @@
     "typecheck": "tsc --noEmit",
     "lint": "npm run typecheck && node scripts/audit.js",
     "audit": "node scripts/audit.js",
-    "build:engine": "tsc -p packages/validator"
+    "build:engine": "tsc -p packages/validator",
+    "test:package": "node --test test/npm-package.test.js",
+    "test:regression": "node --test test/regression-corpus.test.js",
+    "test:fast": "npm run build && SKIP_PACKAGE_TEST=1 node --test test/*.test.js",
+    "hooks:install": "bash scripts/install-hooks.sh"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.19.1",

--- a/packages/validator/package-lock.json
+++ b/packages/validator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pinescript-v6-validator",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pinescript-v6-validator",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.4.5"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pinescript-v6-validator",
-  "version": "0.2.1",
-  "description": "TradingView Pine Script v6 validator and reference dataset \u2014 457 function signatures with explicit overload modelling. The engine behind the Pine Script v6 IDE Tools VS Code extension.",
+  "version": "0.3.0",
+  "description": "TradingView Pine Script v6 validator and reference dataset — 457 function signatures with explicit overload modelling. The engine behind the Pine Script v6 IDE Tools VS Code extension.",
   "keywords": [
     "pinescript",
     "pine-script",

--- a/packages/validator/src/checkRegistry.ts
+++ b/packages/validator/src/checkRegistry.ts
@@ -41,7 +41,7 @@ export const SEMANTIC_CHECKS: Record<SemanticCheckId, SemanticCheck> = {
     id: 'S1',
     severity: Severity.Warning,
     title: 'Possible repainting: request.security() without a historical offset',
-    docAnchor: 'pinescript-strategy#1-repainting-higher-timeframe-data'
+    docAnchor: 'pinescript-strategy#1-repainting-higher-timeframe-data-detected-as-s1'
   },
   S2: {
     id: 'S2',
@@ -49,17 +49,22 @@ export const SEMANTIC_CHECKS: Record<SemanticCheckId, SemanticCheck> = {
     title: 'ta.* called inside a conditional — its history will have gaps',
     docAnchor: 'pinescript-v6#the-execution-model-decides-everything'
   },
+  // Two shapes, one question: does the accumulator's lifetime match its meaning?
+  //   S3a  `x := x + ...` with no `var`   -> resets every bar
+  //   S3b  `var x = 0` re-accumulated in a loop with no reset -> grows unbounded
+  // S3b is the costlier half: it produces a plausible number that drifts, which is
+  // the defect that survives a backtest. One ID so `// pine-ignore: S3` covers both.
   S3: {
     id: 'S3',
     severity: Severity.Warning,
-    title: 'Accumulator reassigned without var — it resets on every bar',
-    docAnchor: 'pinescript-strategy#4-accumulators-without-var'
+    title: 'Accumulator lifetime does not match its meaning',
+    docAnchor: 'pinescript-strategy#4-accumulator-lifetime-both-directions-are-wrong'
   },
   S4: {
     id: 'S4',
     severity: Severity.Warning,
     title: 'Assignment inside and/or — v6 short-circuits and may skip it',
-    docAnchor: 'pinescript-strategy#4-accumulators-without-var'
+    docAnchor: 'pinescript-strategy#4-accumulator-lifetime-both-directions-are-wrong'
   },
   S5: {
     id: 'S5',
@@ -83,7 +88,7 @@ export const SEMANTIC_CHECKS: Record<SemanticCheckId, SemanticCheck> = {
     id: 'S8',
     severity: Severity.Error,
     title: 'Functions cannot be defined inside a block',
-    docAnchor: 'pinescript-v6#language-rules-that-bite'
+    docAnchor: 'pinescript-v6#common-compile-errors'
   },
   S9: {
     id: 'S9',

--- a/packages/validator/src/semanticChecks.ts
+++ b/packages/validator/src/semanticChecks.ts
@@ -228,12 +228,50 @@ function checkRepainting(lines: string[]): ValidationError[] {
  * Deliberately narrow: only a call *inside* a conditional counts. Using the RESULT
  * of an unconditional call in a ternary — `v = ta.rsi(c,14)` then `x = cond ? v : na`
  * — is the correct idiom and by far the more common shape.
+ *
+ * INDENTATION ALONE IS NOT CONDITIONALITY. A user-defined function body is indented
+ * for scope, not for branching, and `ta.*` inside one is the normal way to write a
+ * reusable indicator helper:
+ *
+ *   f_norm(x, n) =>
+ *       ma = ta.sma(x, n)      // runs whenever f_norm is called — not conditional
+ *
+ * Treating every indented line as a block flagged this, which is the false-positive
+ * class the project holds to be worse than a miss. What matters is the nearest
+ * ENCLOSING construct: a control-flow block makes the call conditional, a function
+ * definition does not.
  */
+
+/** `f(x) =>`, `method f(x) =>`, `export f(x) =>` — a definition, not a branch. */
+const FUNCTION_DEF = /^\s*(?:export\s+)?(?:method\s+)?[A-Za-z_][A-Za-z0-9_]*\s*\([^)]*\)\s*=>/;
+
+/** Constructs whose body genuinely runs only sometimes, or more than once per bar. */
+const CONTROL_FLOW = /^\s*(?:if|else|for|while|switch)\b/;
+
 function checkTaInConditional(lines: string[]): ValidationError[] {
   const findings: ValidationError[] = [];
   const taCall = /(?<![a-zA-Z0-9_.])ta\.[a-z_]+\s*\(/g;
 
   const statements = new Set(statementLines(lines).map(s => s.index));
+
+  /**
+   * True when the nearest enclosing block header for `line` is control flow.
+   * Walks upward to the first line with strictly smaller indentation — that is the
+   * construct this line's body belongs to.
+   */
+  const insideControlFlow = (line: number, indent: number): boolean => {
+    for (let j = line - 1; j >= 0; j--) {
+      if (!lines[j].trim()) continue;
+      const outer = lines[j].search(/\S/);
+      if (outer >= indent) continue;
+      if (FUNCTION_DEF.test(lines[j])) return false;
+      if (CONTROL_FLOW.test(lines[j])) return true;
+      // Any other header (a `var x =` continuation, a type block) — keep climbing.
+      indent = outer;
+      if (outer === 0) return false;
+    }
+    return false;
+  };
 
   lines.forEach((text, i) => {
     let match;
@@ -246,9 +284,9 @@ function checkTaInConditional(lines: string[]): ValidationError[] {
       // Both branches are conditional, so both corrupt the indicator's history.
       const inTernary = /\?/.test(before);
 
-      // Inside an indented block: this line starts a statement AND is indented.
       const indent = text.search(/\S/);
-      const inBlock = statements.has(i) && indent > 0;
+      const inBlock =
+        statements.has(i) && indent > 0 && insideControlFlow(i, indent);
 
       if (inTernary || inBlock) {
         findings.push(makeFinding('S2', i + 1, match.index, match[0].length - 1,
@@ -293,6 +331,126 @@ function checkEntryWithoutExit(lines: string[]): ValidationError[] {
     'This script opens positions but never closes them. Add strategy.exit or strategy.close — an entry without an exit is unbounded risk.')];
 }
 
+//──────────────────────────────────────────────────────────
+// S3 — accumulator lifetime
+//──────────────────────────────────────────────────────────
+
+/** `var float sum = 0.0` / `var counter = 0` — a numeric seed, declared once. */
+const VAR_ACCUMULATOR =
+  /^\s*var(?:ip)?\s+(?:[A-Za-z_][A-Za-z0-9_]*\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(-?\d+(?:\.\d+)?|na)\s*$/;
+
+/** A `for`/`while` header and its indentation. */
+const LOOP_HEADER = /^(\s*)(for|while)\b/;
+
+/**
+ * Run-once initialisation is a legitimate reason to accumulate into a `var` with no
+ * reset. Building a lookup table on the first bar is correct code, and flagging it
+ * would be exactly the false positive that gets a validator switched off.
+ */
+const RUN_ONCE_GUARD = /barstate\.is(first|last)|bar_index\s*==\s*0/;
+
+/**
+ * Flag a `var` accumulator that a loop re-accumulates into on every bar without a
+ * reset.
+ *
+ * The original spec had only the opposite shape — an accumulator MISSING `var`,
+ * which resets each bar. This is the inverse, and it is the more expensive half:
+ *
+ *   var float sum = 0.0
+ *   for i = 0 to 9
+ *       sum := sum + close[i]     // adds ten more closes every bar, forever
+ *
+ * The author wanted "sum of the last ten closes" and gets a number that grows for
+ * the life of the chart. A missing `var` produces a visibly constant series; this
+ * produces a plausible one that drifts, which is the defect that survives a
+ * backtest and reaches a funded account.
+ *
+ * The `while` form fails differently and more quietly — the state that the
+ * condition tests survives the bar, so the loop simply never runs again:
+ *
+ *   var int counter = 0
+ *   while counter < 5
+ *       counter += 1              // on bar 2 counter is already 5
+ *
+ * Structural, not an inference about intent: a `var` with a numeric seed,
+ * re-assigned to itself inside a loop body, with no reset between the declaration
+ * and the loop.
+ */
+function checkAccumulatorLifetime(lines: string[]): ValidationError[] {
+  const declared = new Map<string, number>();
+
+  lines.forEach((text, i) => {
+    const match = VAR_ACCUMULATOR.exec(text);
+    if (match) declared.set(match[1], i);
+  });
+
+  if (declared.size === 0) return [];
+
+  const findings: ValidationError[] = [];
+  const reported = new Set<string>();
+
+  for (let i = 0; i < lines.length; i++) {
+    const header = LOOP_HEADER.exec(lines[i]);
+    if (!header) continue;
+
+    const loopIndent = header[1].length;
+    const keyword = header[2];
+
+    // Body = the contiguous run of more-indented lines beneath the header.
+    const body: number[] = [];
+    for (let j = i + 1; j < lines.length; j++) {
+      if (!lines[j].trim()) continue;
+      const indent = lines[j].search(/\S/);
+      if (indent <= loopIndent) break;
+      body.push(j);
+    }
+    if (body.length === 0) continue;
+
+    for (const [name, declLine] of declared) {
+      if (reported.has(name) || declLine > i) continue;
+
+      const selfAssign = new RegExp(
+        `(?<![\\w.])${name}\\s*(?:(?:\\+|-|\\*|/|%)=|:=\\s*(?![=]).*(?<![\\w.])${name}(?![\\w]))`
+      );
+      const hit = body.find(j => selfAssign.test(lines[j]));
+      if (hit === undefined) continue;
+
+      // A reset before the loop makes this correct: the `var` is a reused buffer
+      // rather than a running total. It must run every bar, so it has to sit at or
+      // outside the loop's own indentation.
+      const resetPattern = new RegExp(`^\\s*${name}\\s*:=\\s*(?![=])(.*)$`);
+      let wasReset = false;
+      let runOnce = false;
+
+      for (let j = declLine + 1; j < i; j++) {
+        const indent = lines[j].search(/\S/);
+        if (RUN_ONCE_GUARD.test(lines[j]) && indent <= loopIndent) runOnce = true;
+
+        const reset = resetPattern.exec(lines[j]);
+        if (reset && indent <= loopIndent &&
+            !new RegExp(`(?<![\\w.])${name}(?![\\w])`).test(reset[1])) {
+          wasReset = true;
+        }
+      }
+      if (wasReset || runOnce) continue;
+
+      reported.add(name);
+      const column = lines[hit].search(/\S/);
+
+      findings.push(makeFinding('S3', hit + 1, column < 0 ? 0 : column, name.length,
+        keyword === 'while'
+          ? `'${name}' is declared with var, so it keeps its value across bars. ` +
+            `On the next bar the while condition is already false and this loop never runs again. ` +
+            `Reset '${name}' before the loop, or drop var if it is per-bar state.`
+          : `'${name}' is declared with var, so it persists across bars and this loop adds to it ` +
+            `again on every bar — it grows without bound. Drop var if you want a per-bar total, ` +
+            `or reset '${name}' before the loop.`));
+    }
+  }
+
+  return findings;
+}
+
 /** Index of the ')' matching the '(' at `openIndex`, or -1 if it never closes. */
 function matchingParen(text: string, openIndex: number): number {
   let depth = 0;
@@ -325,6 +483,7 @@ export function runSemanticChecks(source: string): ValidationError[] {
     ...checkGlobalScopeOnly(lines),
     ...checkRepainting(lines),
     ...checkTaInConditional(lines),
+    ...checkAccumulatorLifetime(lines),
     ...checkEntryWithoutExit(lines),
   ].sort((a, b) => a.line - b.line || a.column - b.column);
 }

--- a/scripts/audit.js
+++ b/scripts/audit.js
@@ -397,6 +397,67 @@ function auditCi() {
   }
 }
 
+
+//──────────────────────────────────────────────────────────
+// Lockfile
+//
+// CI installs with `npm ci`, which REFUSES to run when package-lock.json disagrees
+// with package.json. A version bump or a changed dependency range that forgets the
+// lockfile does not fail locally — `npm test` uses whatever is already in
+// node_modules — and then breaks every job in CI at the install step, before a
+// single test runs.
+//
+// It has drifted here silently: the lock sat at 0.6.0 while the released extension
+// was 0.6.1, and the engine range diverged during a release.
+//──────────────────────────────────────────────────────────
+
+function auditLockfile() {
+  if (!exists('package-lock.json')) {
+    fail('lockfile', 'package-lock.json is missing; `npm ci` cannot run in CI');
+    return;
+  }
+
+  const manifest = JSON.parse(read('package.json'));
+  const lock = JSON.parse(read('package-lock.json'));
+
+  if (lock.version !== manifest.version) {
+    fail('lockfile',
+      `package-lock.json is at ${lock.version} but package.json is at ` +
+      `${manifest.version} — run \`npm install\`. CI installs with \`npm ci\`, ` +
+      `which fails outright on this.`);
+    return;
+  }
+
+  const locked = (lock.packages && lock.packages[''] && lock.packages[''].dependencies) || {};
+  const declared = manifest.dependencies || {};
+  const drifted = Object.entries(declared)
+    .filter(([name, range]) => locked[name] !== range)
+    .map(([name, range]) => `${name}: package.json wants ${range}, lock has ${locked[name] || '(absent)'}`);
+
+  if (drifted.length) {
+    fail('lockfile', `dependency ranges disagree — run \`npm install\`:\n         ` +
+      drifted.join('\n         '));
+    return;
+  }
+
+  // The engine is bundled into the VSIX at build time, so a pin ahead of what is
+  // actually resolvable produces an extension whose engine cannot be installed —
+  // discovered at activation, on a user's machine.
+  const enginePin = declared['pinescript-v6-validator'];
+  if (enginePin) {
+    const resolved = lock.packages && lock.packages['node_modules/pinescript-v6-validator'];
+    if (!resolved) {
+      fail('lockfile', 'the engine is declared but absent from the lockfile');
+      return;
+    }
+    pass('lockfile',
+      `in sync at ${lock.version}; engine ${enginePin} resolves to ${resolved.version}`);
+    return;
+  }
+
+  pass('lockfile', `in sync at ${lock.version}`);
+}
+
 //──────────────────────────────────────────────────────────
 
 auditNpmScripts();
@@ -408,6 +469,7 @@ auditDataCurrency();
 auditDiagnosticCoverage();
 auditEnginePortability();
 auditCi();
+auditLockfile();
 
 const ICON = { PASS: '[32m PASS[0m', WARN: '[33m WARN[0m', FAIL: '[31m FAIL[0m' };
 const counts = { PASS: 0, WARN: 0, FAIL: 0 };

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Activate .githooks/pre-commit for this clone.
+#
+# Two situations, and conflating them breaks one of them:
+#
+#   1. core.hooksPath already points somewhere else — typically a machine-wide
+#      secret scanner. Overwriting it would silently disable that protection, which
+#      is a bad trade for a test gate. A well-behaved global hook chains to
+#      .githooks/pre-commit, so there is nothing to do but confirm.
+#
+#   2. core.hooksPath is unset. Point it at .githooks, which is tracked, so the hook
+#      arrives with the clone instead of having to be remembered.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+chmod +x .githooks/pre-commit
+
+existing="$(git config core.hooksPath || true)"
+
+if [ -z "$existing" ]; then
+  git config core.hooksPath .githooks
+  echo "core.hooksPath -> .githooks"
+  echo "pre-commit active: typecheck, full test suite, examples/ validation."
+  exit 0
+fi
+
+if [ "$existing" = ".githooks" ]; then
+  echo "Already active (core.hooksPath = .githooks)."
+  exit 0
+fi
+
+echo "core.hooksPath is set to: $existing"
+if [ -x "$existing/pre-commit" ] && grep -q '\.githooks/pre-commit' "$existing/pre-commit" 2>/dev/null; then
+  echo "That hook chains to .githooks/pre-commit — nothing to change."
+else
+  echo
+  echo "WARNING  It does NOT appear to chain to .githooks/pre-commit, so this repo's"
+  echo "         gate will not run. Either add the chain there, or run:"
+  echo "             git config core.hooksPath .githooks"
+  echo "         Be aware that replaces whatever $existing was doing."
+  exit 1
+fi

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -1,0 +1,94 @@
+/**
+ * examples/ must stay valid, and the negative fixtures must stay invalid.
+ *
+ * This directory is user-facing and is also where the accumulator defect propagated:
+ * a demo file carried a `var` total that a loop re-accumulated on every bar, the
+ * validator called it clean, and a person found it by eye. A demo file teaches
+ * whatever it contains, so it is held to the same standard as shipped code.
+ *
+ * Two categories, distinguished by a marker rather than a hard-coded list — a list
+ * drifts, a marker sits in the file it describes:
+ *
+ *   normal    -> zero ERRORS. Warnings are allowed: several examples legitimately
+ *                demonstrate S1 on higher-timeframe data, and suppressing those
+ *                would misrepresent what the tool does.
+ *
+ *   marked    -> `// pine-expect: invalid` in the header. These exist to prove the
+ *                validator catches something, so they must produce at least one
+ *                error. The marker excuses a file from the clean sweep; it does NOT
+ *                exempt it from being checked. Without this half, marking a file
+ *                would be a way to silence a real regression.
+ */
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { validatePineScript } = require('../packages/validator/dist/index.js');
+
+const EXAMPLES = path.join(__dirname, '..', 'examples');
+const MARKER = /^\s*\/\/\s*pine-expect:\s*invalid\b/m;
+
+function collect(dir, found = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) collect(full, found);
+    else if (entry.name.endsWith('.pine')) found.push(full);
+  }
+  return found;
+}
+
+const files = collect(EXAMPLES).map(full => {
+  const source = fs.readFileSync(full, 'utf8');
+  return {
+    rel: path.relative(EXAMPLES, full),
+    source,
+    negative: MARKER.test(source),
+  };
+});
+
+describe('examples/', () => {
+  test('there are example files to check', () => {
+    // Guards against a glob that silently matches nothing, which would make every
+    // assertion below vacuously true.
+    assert.ok(files.length > 5, `only found ${files.length} .pine files`);
+  });
+
+  for (const file of files.filter(f => !f.negative)) {
+    test(`${file.rel} has no errors`, () => {
+      const errors = validatePineScript(file.source).filter(d => d.severity === 0);
+      assert.deepStrictEqual(
+        errors.map(e => `L${e.line}: ${e.message}`), [],
+        'An example that cannot compile teaches whatever it contains. Fix the Pine, ' +
+        'or mark the file `// pine-expect: invalid` if it is a negative fixture.'
+      );
+    });
+  }
+
+  for (const file of files.filter(f => f.negative)) {
+    test(`${file.rel} is a negative fixture and still fails`, () => {
+      const errors = validatePineScript(file.source).filter(d => d.severity === 0);
+      assert.ok(errors.length > 0,
+        'This file is marked `pine-expect: invalid` but now validates clean. Either ' +
+        'the validator has regressed and stopped catching what this fixture proves, ' +
+        'or the file was fixed and the marker should be removed.');
+    });
+  }
+
+  test('no example carries an unreset var accumulator', () => {
+    // The specific defect that reached a user. Belt and braces over S3 itself: if
+    // the check regresses, this still fails, and it fails pointing at examples/.
+    const offenders = [];
+    for (const file of files) {
+      for (const d of validatePineScript(file.source)) {
+        if (d.checkId === 'S3') offenders.push(`${file.rel}:${d.line}`);
+      }
+    }
+    assert.deepStrictEqual(offenders, [],
+      'S3 fires on an example. `var` persists across bars, so a per-bar total must ' +
+      'not be var, or must be reset before the loop.');
+  });
+});

--- a/test/npm-package.test.js
+++ b/test/npm-package.test.js
@@ -1,0 +1,262 @@
+/**
+ * The published artefact, not the source tree.
+ *
+ * This packs `packages/validator` exactly as `npm publish` would, installs the
+ * tarball into a throwaway project, and drives it through its public entry point —
+ * `require('pinescript-v6-validator')` — with no path into this repository.
+ *
+ * WHY A SEPARATE SUITE
+ *
+ * Every recurring failure in this project's history has had the same shape: correct
+ * in `src/`, broken in the thing users actually receive.
+ *
+ *   - doc anchors that resolved against the source registry and were dead in the
+ *     shipped package, because the package had not been rebuilt
+ *   - a VSIX that died at activation because the engine was excluded from the bundle
+ *   - a local scratchpad path that leaked into a dependency range during testing,
+ *     which would have made `npm install` fail for everyone
+ *   - an MCP manifest declaring a server file that did not exist, which passed
+ *     schema validation cleanly
+ *
+ * No suite that imports from `packages/validator/dist` can see any of those. This
+ * one can, because it deliberately throws that access away.
+ *
+ * It runs the SAME corpus as test/regression-corpus.test.js. One table, two
+ * environments: source and published cannot drift, because there is nothing to drift.
+ *
+ * COST: one `npm pack` plus one offline `npm install`, a few seconds. Set
+ * SKIP_PACKAGE_TEST=1 to skip it during a tight edit loop — but never in CI, and
+ * never before a release.
+ */
+
+'use strict';
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { CASES, SUPPRESSION_CASES } = require('./regression-corpus.js');
+
+const PACKAGE_DIR = path.join(__dirname, '..', 'packages', 'validator');
+const PACKAGE_NAME = 'pinescript-v6-validator';
+const SKIP = process.env.SKIP_PACKAGE_TEST === '1';
+
+let workspace = null;
+/** The module object, obtained by name from the installed package. */
+let installed = null;
+/** package.json as it exists INSIDE the tarball. */
+let publishedManifest = null;
+
+function run(command, args, cwd) {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+describe('Published npm package', { skip: SKIP && 'SKIP_PACKAGE_TEST=1' }, () => {
+  before(() => {
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'pine-pkg-'));
+
+    // Build first. Packing a stale dist/ is precisely the drift this suite exists
+    // to catch, and it would produce a confusing pass rather than a useful failure.
+    run('npm', ['run', 'build'], PACKAGE_DIR);
+
+    const packed = run('npm', ['pack', '--pack-destination', workspace], PACKAGE_DIR)
+      .trim().split('\n').pop().trim();
+    const tarball = path.join(workspace, packed);
+
+    fs.writeFileSync(
+      path.join(workspace, 'package.json'),
+      JSON.stringify({ name: 'consumer', version: '1.0.0', private: true }, null, 2)
+    );
+
+    run('npm', ['install', tarball, '--no-audit', '--no-fund'], workspace);
+
+    const installedDir = path.join(workspace, 'node_modules', PACKAGE_NAME);
+    publishedManifest = JSON.parse(
+      fs.readFileSync(path.join(installedDir, 'package.json'), 'utf8')
+    );
+
+    // By NAME, resolved from the consumer project — the same resolution a user gets.
+    installed = require(require.resolve(PACKAGE_NAME, { paths: [workspace] }));
+  }, { timeout: 300000 });
+
+  after(() => {
+    if (workspace) fs.rmSync(workspace, { recursive: true, force: true });
+  });
+
+  //────────────────────────────────────────────────────────
+  // The package installs and presents its API
+  //────────────────────────────────────────────────────────
+
+  test('installs from a tarball and loads by name', () => {
+    assert.ok(installed, 'require() by package name must resolve');
+  });
+
+  test('exports everything downstream code depends on', () => {
+    // The extension and the MCP server both consume these. Dropping one is a major
+    // break that a source-tree test would never notice.
+    for (const name of [
+      'validatePineScript', 'runSemanticChecks', 'runDocumentChecks',
+      'AccurateValidator', 'SEMANTIC_CHECKS', 'Severity',
+      'extractSuppressions', 'applySuppressions',
+      'blankComments', 'blankStrings', 'PINE_FUNCTIONS_MERGED',
+    ]) {
+      assert.ok(name in installed, `the published package must export ${name}`);
+    }
+  });
+
+  test('ships type declarations alongside the entry point', () => {
+    const dir = path.join(workspace, 'node_modules', PACKAGE_NAME);
+    assert.ok(fs.existsSync(path.join(dir, publishedManifest.main)),
+      `main "${publishedManifest.main}" is missing from the tarball`);
+    assert.ok(fs.existsSync(path.join(dir, publishedManifest.types)),
+      `types "${publishedManifest.types}" is missing from the tarball`);
+  });
+
+  //────────────────────────────────────────────────────────
+  // The manifest is publishable
+  //────────────────────────────────────────────────────────
+
+  test('no dependency in ANY manifest resolves to a local path', () => {
+    // `npm install ./some.tgz` rewrites package.json in place. Committing that ships
+    // something nobody else can install and leaks a local directory layout. It has
+    // happened here: a scratchpad tarball path landed in a dependency range during
+    // testing and was caught by eye, not by a gate.
+    //
+    // Checking only the published manifest would be vacuous — the engine has no
+    // dependencies at all, so that assertion could never fail. The risk lives in the
+    // CONSUMERS, so every manifest in the repo is checked.
+    const manifests = [
+      path.join(__dirname, '..', 'package.json'),
+      path.join(PACKAGE_DIR, 'package.json'),
+    ];
+
+    const offenders = [];
+    for (const file of manifests) {
+      if (!fs.existsSync(file)) continue;
+      const manifest = JSON.parse(fs.readFileSync(file, 'utf8'));
+      const deps = {
+        ...(manifest.dependencies || {}),
+        ...(manifest.devDependencies || {}),
+        ...(manifest.peerDependencies || {}),
+      };
+      for (const [name, range] of Object.entries(deps)) {
+        if (/^(file:|link:|\/|\.\.?\/)/.test(String(range))) {
+          offenders.push(`${path.basename(path.dirname(file))}/package.json: ${name} -> ${range}`);
+        }
+      }
+    }
+    assert.deepStrictEqual(offenders, [],
+      'a dependency points at a local path and would break `npm install` for users');
+  });
+
+  test('the extension depends on a version of the engine that exists', () => {
+    // The extension bundles the engine into dist/engine at build time. A pin ahead of
+    // what is published produces a VSIX whose engine cannot be installed, which is
+    // only discovered at activation — on a user's machine.
+    const root = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')
+    );
+    const pin = (root.dependencies || {})[PACKAGE_NAME];
+    assert.ok(pin, 'the extension must depend on the engine explicitly');
+
+    const wanted = pin.replace(/^[\^~]/, '');
+    const [wantMajor, wantMinor] = wanted.split('.').map(Number);
+    const [haveMajor, haveMinor] = publishedManifest.version.split('.').map(Number);
+
+    assert.ok(
+      haveMajor > wantMajor || (haveMajor === wantMajor && haveMinor >= wantMinor),
+      `the extension pins ${pin} but the engine in this tree is ` +
+      `${publishedManifest.version} — publish the engine before the extension`
+    );
+  });
+
+  test('the tarball carries no absolute path from this machine', () => {
+    const dir = path.join(workspace, 'node_modules', PACKAGE_NAME);
+    const offenders = [];
+    const walk = current => {
+      for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+        const full = path.join(current, entry.name);
+        if (entry.isDirectory()) { walk(full); continue; }
+        if (!/\.(js|json|d\.ts|md)$/.test(entry.name)) continue;
+        const text = fs.readFileSync(full, 'utf8');
+        if (/\/Users\/|\/home\/[a-z]|[A-Z]:\\\\Users/.test(text)) {
+          offenders.push(path.relative(dir, full));
+        }
+      }
+    };
+    walk(dir);
+    assert.deepStrictEqual(offenders, [],
+      'these published files embed an absolute path from the build machine');
+  });
+
+  test('declares a version, a licence and a repository', () => {
+    assert.match(publishedManifest.version, /^\d+\.\d+\.\d+/, 'version');
+    assert.ok(publishedManifest.license, 'licence');
+    assert.ok(publishedManifest.repository, 'repository');
+  });
+
+  //────────────────────────────────────────────────────────
+  // The regression corpus, against the published artefact
+  //────────────────────────────────────────────────────────
+
+  describe('regression corpus', () => {
+    for (const entry of [...CASES, ...SUPPRESSION_CASES]) {
+      test(entry.name, () => {
+        const diagnostics = installed.validatePineScript(entry.code);
+        const ids = diagnostics.map(
+          d => d.checkId || (d.severity === 0 ? 'error' : 'warn')
+        );
+        const context =
+          `\n\n  Regression found ${entry.found}\n  ${entry.why}` +
+          `\n\n  Got: ${ids.join(', ') || '(nothing)'}` +
+          `\n\n  This ran against the PUBLISHED package. If the same case passes in` +
+          `\n  test/regression-corpus.test.js, the source is right and the build or` +
+          `\n  the "files" field is wrong.`;
+
+        if (entry.expect === null) {
+          const real = diagnostics.filter(d => d.checkId || d.severity === 0);
+          assert.strictEqual(real.length, 0,
+            'This code is CORRECT and must produce no findings.' + context);
+        } else {
+          assert.ok(ids.includes(entry.expect), `Expected ${entry.expect}.` + context);
+        }
+      });
+    }
+  });
+
+  //────────────────────────────────────────────────────────
+  // The check registry survives publication
+  //────────────────────────────────────────────────────────
+
+  test('every semantic check reaches consumers with its metadata intact', () => {
+    const registry = installed.SEMANTIC_CHECKS;
+    assert.deepStrictEqual(Object.keys(registry).sort(),
+      ['S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7', 'S8', 'S9']);
+
+    for (const [id, check] of Object.entries(registry)) {
+      assert.strictEqual(check.id, id);
+      assert.ok(check.title && check.title.length > 15, `${id}: title`);
+      // Resolution against real headings is enforced by `make anchors` in the
+      // plugin repo, which owns the skills. Here we only prove the field survived
+      // the build — the anchors were once correct in src/ and dead in the package.
+      const [skill, anchor] = String(check.docAnchor || '').split('#');
+      assert.match(skill, /^pinescript-[a-z0-9]+$/, `${id}: docAnchor skill`);
+      assert.ok(anchor && anchor.length > 3, `${id}: docAnchor section`);
+    }
+  });
+
+  test('the published version matches the working tree', () => {
+    const local = JSON.parse(
+      fs.readFileSync(path.join(PACKAGE_DIR, 'package.json'), 'utf8')
+    );
+    assert.strictEqual(publishedManifest.version, local.version,
+      'the packed tarball is not built from the current package.json');
+  });
+});

--- a/test/regression-corpus.js
+++ b/test/regression-corpus.js
@@ -1,0 +1,388 @@
+/**
+ * The regression corpus — every defect this validator has ever shipped, locked open.
+ *
+ * WHY THIS FILE EXISTS
+ *
+ * Each entry below is a bug that reached a user or survived a review. Several were
+ * found only because somebody read a file by eye that the tool had just called
+ * clean. The corpus exists so that none of them can come back quietly.
+ *
+ * It is deliberately DATA, not tests. The same table is executed twice:
+ *
+ *   test/regression-corpus.test.js  -> against the local build (packages/validator/dist)
+ *   test/npm-package.test.js        -> against the PACKED, INSTALLED tarball
+ *
+ * That second run is the point. Every recurring failure in this project's history
+ * has been of one shape: correct in the source tree, broken in the published
+ * artefact. Dead doc anchors that resolved in `src/` and not in the shipped package.
+ * A VSIX whose engine was excluded by .vscodeignore. A local scratchpad path that
+ * leaked into a dependency range. Testing `src/` cannot see any of those.
+ *
+ * ADDING A CASE
+ *
+ * When a defect is found, add it here BEFORE fixing it, and give `found` a real
+ * date and a one-line account of how it escaped. A case with no `why` is a case
+ * nobody will understand in six months.
+ *
+ * `expect` is the checkId that must appear ('S1'…'S9'), the string 'error' for a
+ * syntactic diagnostic, or null meaning the code is CORRECT and nothing may fire.
+ * A null case is not filler — a false positive on working code is worse here than
+ * a miss, because it teaches people to ignore the tool.
+ */
+
+'use strict';
+
+const IND = '//@version=6\nindicator("t", overlay=true)\n';
+const STR = '//@version=6\nstrategy("t", overlay=true)\n';
+
+/** @type {Array<{name:string, code:string, expect:string|null, found:string, why:string}>} */
+const CASES = [
+  //────────────────────────────────────────────────────────
+  // S1 — repainting
+  //────────────────────────────────────────────────────────
+  {
+    name: 'S1: request.security without an offset repaints',
+    code: IND + 'd = request.security(syminfo.tickerid, "D", close)\nplot(d)\n',
+    expect: 'S1',
+    found: '2026-08-05',
+    why:
+      'The single most-cited Pine defect in the literature, and the reason semantic ' +
+      'checking exists at all. If this one ever goes quiet, the tool has lost its point.',
+  },
+  {
+    name: 'S1: a MULTI-LINE request.security is still assessed',
+    code: IND + 'd = request.security(syminfo.tickerid,\n     "D",\n     close)\nplot(d)\n',
+    expect: 'S1',
+    found: '2026-08-08',
+    why:
+      'The check bailed whenever the parentheses did not close on one line, behind a ' +
+      'comment claiming the call was "assessed on its own line". Nothing assessed it. ' +
+      'Wrapping is the NORMAL formatting for this function, so most real repainting escaped.',
+  },
+  {
+    name: 'S1: close[1] is the anti-repainting idiom and must not warn',
+    code: IND + 'd = request.security(syminfo.tickerid, "D", close[1])\nplot(d)\n',
+    expect: null,
+    found: '2026-08-05',
+    why: 'Flagging the documented fix would punish correct code and train people to ignore S1.',
+  },
+  {
+    name: 'S1: an explicit lookahead_off means the author decided',
+    code: IND + 'd = request.security(syminfo.tickerid, "D", close, lookahead=barmerge.lookahead_off)\nplot(d)\n',
+    expect: null,
+    found: '2026-08-05',
+    why: 'S1 is a question about intent; stating the intent answers it.',
+  },
+
+  //────────────────────────────────────────────────────────
+  // S2 — ta.* conditionality
+  //────────────────────────────────────────────────────────
+  {
+    name: 'S2: ta.* in the TRUE branch of a ternary',
+    code: IND + 'x = close > open ? ta.sma(close, 20) : na\nplot(x)\n',
+    expect: 'S2',
+    found: '2026-08-05',
+    why:
+      'The original S2 case. ta.* carries state across bars, so a call that only runs ' +
+      'on some bars develops gaps in its history and every later value is wrong.',
+  },
+  {
+    name: 'S2: ta.* in the FALSE branch of a ternary',
+    code: IND + 'x = close > open ? na : ta.sma(close, 20)\nplot(x)\n',
+    expect: 'S2',
+    found: '2026-08-08',
+    why:
+      'The test was `!/\\?[^:]*$/`, which only ever inspected the true branch. ' +
+      'Both branches are conditional and both leave gaps in the indicator history.',
+  },
+  {
+    name: 'S2: ta.* inside an if body',
+    code: IND + 'var float v = 0.0\nif close > open\n    v := ta.sma(close, 20)\nplot(v)\n',
+    expect: 'S2',
+    found: '2026-08-05',
+    why:
+      'The block form of the same defect. An if body runs on some bars only, so the ' +
+      'ta.* inside it advances on some bars only.',
+  },
+  {
+    name: 'S2: ta.* inside a for body',
+    code: IND + 'var float v = 0.0\nv := 0.0\nfor i = 0 to 2\n    v := ta.ema(close, 20)\nplot(v)\n',
+    expect: 'S2',
+    found: '2026-08-08',
+    why: 'Loop iterations are not bars. Calling ta.* n times per bar corrupts its state.',
+  },
+  {
+    name: 'S2: a ta.* call in a USER FUNCTION body is correct and must not warn',
+    code: IND + 'f_norm(x, n) =>\n    ma = ta.sma(x, n)\n    na(ma) ? na : x / ma\nplot(f_norm(close, 20))\n',
+    expect: null,
+    found: '2026-08-08',
+    why:
+      'S2 treated every indented line as a conditional block. A function body is ' +
+      'indented for SCOPE, not branching, and this is the normal way to write a ' +
+      'reusable helper. It fired on a real working script in examples/. ' +
+      'A false positive on correct code is worse than a miss.',
+  },
+  {
+    name: 'S2: a ta.* call in a method body must not warn',
+    code: IND + 'method smooth(float x) =>\n    ta.sma(x, 5)\nplot(close.smooth())\n',
+    expect: null,
+    found: '2026-08-08',
+    why:
+      'Methods are function definitions too, and the fix keyed off a regex for the ' +
+      'definition form. A pattern that missed the `method` modifier would silently ' +
+      'reintroduce the false positive for every user-defined method.',
+  },
+  {
+    name: 'S2: an if NESTED in a function still warns',
+    code: IND + 'f(x) =>\n    if x > 0\n        ta.sma(x, 5)\nplot(f(close))\n',
+    expect: 'S2',
+    found: '2026-08-08',
+    why:
+      'The function-body exemption must not become a blanket amnesty. What matters ' +
+      'is the NEAREST enclosing construct, not any enclosing construct.',
+  },
+  {
+    name: 'S2: using the RESULT of an unconditional call in a ternary is correct',
+    code: IND + 'v = ta.rsi(close, 14)\nx = close > open ? v : na\nplot(x)\n',
+    expect: null,
+    found: '2026-08-05',
+    why: 'This is the documented remedy for S2. Flagging it would leave no way out.',
+  },
+
+  //────────────────────────────────────────────────────────
+  // S3 — accumulator lifetime
+  //────────────────────────────────────────────────────────
+  {
+    name: 'S3: a var total re-accumulated by a for loop grows without bound',
+    code: IND + 'var float sum = 0.0\nfor i = 0 to 9\n    sum := sum + close[i]\nplot(sum)\n',
+    expect: 'S3',
+    found: '2026-08-08',
+    why:
+      'Reported by a user who read examples/test-v6-features.pine by eye after the ' +
+      'tool called it clean. `var` persists, so this adds ten more closes on every ' +
+      'bar for the life of the chart. The spec had only the OPPOSITE shape (an ' +
+      'accumulator missing `var`), which is the cheaper half — that one produces a ' +
+      'visibly constant series, this one produces a plausible number that drifts.',
+  },
+  {
+    name: 'S3: a var counter makes its own while loop unreachable',
+    code: IND + 'var int counter = 0\nwhile counter < 5\n    counter += 1\nplot(counter)\n',
+    expect: 'S3',
+    found: '2026-08-08',
+    why:
+      'Second instance in the same file, quieter than the first: on bar two the ' +
+      'counter is already at its terminal value, so the body never runs again.',
+  },
+  {
+    name: 'S3: a per-bar total that correctly omits var must not warn',
+    code: IND + 'float sum = 0.0\nfor i = 0 to 9\n    sum += close[i]\nplot(sum)\n',
+    expect: null,
+    found: '2026-08-08',
+    why: 'No var means it resets each bar, which is exactly what a per-bar total wants.',
+  },
+  {
+    name: 'S3: a var reset before the loop is a buffer, not a leak',
+    code: IND + 'var float sum = 0.0\nsum := 0.0\nfor i = 0 to 9\n    sum += close[i]\nplot(sum)\n',
+    expect: null,
+    found: '2026-08-08',
+    why: 'Reusing an allocation is legitimate provided it is cleared every bar.',
+  },
+  {
+    name: 'S3: run-once initialisation on the first bar is correct',
+    code: IND + 'var float seed = 0.0\nif barstate.isfirst\n    for i = 0 to 9\n        seed += close[i]\nplot(seed)\n',
+    expect: null,
+    found: '2026-08-08',
+    why: 'Building a lookup table on bar one is THE legitimate reason to accumulate into a var.',
+  },
+  {
+    name: 'S3: a genuine running total outside any loop is correct',
+    code: IND + 'var float total = 0.0\ntotal := total + volume\nplot(total)\n',
+    expect: null,
+    found: '2026-08-08',
+    why: 'Cumulative volume is the textbook correct use of var. Flagging it would be absurd.',
+  },
+
+  //────────────────────────────────────────────────────────
+  // S5 / S6 / S7 / S8 — platform limits and scope
+  //────────────────────────────────────────────────────────
+  {
+    name: 'S7: plot() indented inside an if will not compile',
+    code: IND + 'if close > open\n    plot(close)\n',
+    expect: 'S7',
+    found: '2026-08-05',
+    why: 'plot takes a series; conditional plotting is done by passing na, not by branching.',
+  },
+  {
+    name: 'S7: a plot() wrapped across lines is not "indented"',
+    code: IND + 'plot(close,\n     title="c",\n     color=color.red)\n',
+    expect: null,
+    found: '2026-08-06',
+    why:
+      'Continuation lines are indented as formatting. Treating them as scope flagged ' +
+      'every multi-line plot in existence.',
+  },
+  {
+    name: 'S8: a function defined inside a block will not compile',
+    code: IND + 'if close > open\n    f(x) => x * 2\nplot(close)\n',
+    expect: 'S8',
+    found: '2026-08-05',
+    why:
+      'Pine requires definitions at column 0. Detectable without an AST, which is why ' +
+      'it shipped while the AST path remains broken.',
+  },
+  {
+    name: 'S8: calling a function inside a block is not defining one',
+    code: IND + 'if close > open\n    y = math.max(1, 2)\nplot(close)\n',
+    expect: null,
+    found: '2026-08-06',
+    why: 'The => arrow is what distinguishes a definition from a call.',
+  },
+
+  //────────────────────────────────────────────────────────
+  // S9 — unbounded risk
+  //────────────────────────────────────────────────────────
+  {
+    name: 'S9: an entry with no exit anywhere',
+    code: STR + 'if close > open\n    strategy.entry("L", strategy.long)\n',
+    expect: 'S9',
+    found: '2026-08-05',
+    why:
+      'The original S9 case. A position opened with no mechanism anywhere in the ' +
+      'script to close it is unbounded risk on a real account.',
+  },
+  {
+    name: 'S9: strategy.cancel is NOT an exit',
+    code: STR + 'if close > open\n    strategy.entry("L", strategy.long)\n' +
+      'if close < open\n    strategy.cancel("L")\n',
+    expect: 'S9',
+    found: '2026-08-08',
+    why:
+      'cancel withdraws a PENDING ORDER; it does not close an open position. Counting ' +
+      'it as an exit let a strategy with genuinely unbounded risk pass clean — the ' +
+      'precise thing S9 exists to catch.',
+  },
+  {
+    name: 'S9: strategy.exit satisfies the check',
+    code: STR + 'if close > open\n    strategy.entry("L", strategy.long)\n' +
+      'if close < open\n    strategy.exit("X", from_entry="L", stop=1.0)\n',
+    expect: null,
+    found: '2026-08-05',
+    why:
+      'The paired negative for S9. Without it the check could be satisfied by always ' +
+      'firing, which would be useless and indistinguishable in a one-sided suite.',
+  },
+
+  //────────────────────────────────────────────────────────
+  // Syntactic — the false-positive history
+  //────────────────────────────────────────────────────────
+  {
+    name: 'syntactic: a misspelled parameter name is named in the diagnostic',
+    code: IND + 'l = line.new(x1=1, y1=2, x2=3, y2=4, colour=color.red)\n',
+    expect: 'error',
+    found: '2026-08-04',
+    why: 'The most common Pine compile error, and the reason this project exists.',
+  },
+  {
+    name: 'FP: the coordinate overload of line.new is official v6',
+    code: IND + 'l = line.new(x1=bar_index[1], y1=low[1], x2=bar_index, y2=high)\n',
+    expect: null,
+    found: '2026-08-04',
+    why:
+      'line.new, box.new and label.new each have a chart.point form AND a coordinate ' +
+      'form. Flattening them into one signature made ten valid calls look invalid.',
+  },
+  {
+    name: 'FP: the coordinate overload of box.new is official v6',
+    code: IND + 'b = box.new(left=bar_index[5], top=high, right=bar_index, bottom=low)\n',
+    expect: null,
+    found: '2026-08-04',
+    why:
+      'Same overload defect as line.new. Listed separately because the fix was per ' +
+      'signature, so one could regress without the other.',
+  },
+  {
+    name: 'FP: a comma inside a string is not an argument separator',
+    code: IND + 'c = close > open\n' +
+      'alertcondition(c, title="T", message="Conditions met, reduce size or tighten stops")\n',
+    expect: null,
+    found: '2026-08-06',
+    why:
+      'Arguments were split on every comma with no awareness of string literals, and ' +
+      'the argument list was captured with ([^)]+) which truncated at the first nested ' +
+      'paren. 28 false errors on one file.',
+  },
+  {
+    name: 'FP: commented-out code must not be validated',
+    code: IND + '// l = line.new(x1=1, y1=2, colour=color.red)\nplot(close)\n',
+    expect: null,
+    found: '2026-08-06',
+    why:
+      'Neither diagnostic path stripped comments. Fixing it then hid //@version=6, ' +
+      'which is itself a comment — so the version check reads the ORIGINAL text.',
+  },
+  {
+    name: 'the version directive is still seen after comment blanking',
+    code: 'plot(close)\n',
+    expect: 'warn',
+    found: '2026-08-06',
+    why:
+      'Regression guard for the fix above: a file with no //@version must still be ' +
+      'reported, which only works if the version check predates comment blanking.',
+  },
+  {
+    name: 'plotshape uses style=, not shape=',
+    code: IND + 'plotshape(close > open, shape=shape.triangleup)\n',
+    expect: 'error',
+    found: '2026-08-06',
+    why:
+      'Caught by documentChecks rather than the validator. A consumer wired to only ' +
+      'one of the two paths calls this clean and silently disagrees with the editor.',
+  },
+  {
+    name: 'a clean idiomatic script produces nothing at all',
+    code: IND + 'len = input.int(20, "Length")\nema = ta.ema(close, len)\nplot(ema, color=color.blue)\n',
+    expect: null,
+    found: '2026-08-04',
+    why:
+      'The most important case in the file. If ordinary correct Pine warns, nothing ' +
+      'else here matters.',
+  },
+];
+
+/**
+ * Suppression is a separate contract: a semantic finding can be silenced by an
+ * author who has considered it, a compile error can never be.
+ */
+const SUPPRESSION_CASES = [
+  {
+    name: 'a targeted // pine-ignore silences that check',
+    code: IND + 'd = request.security(syminfo.tickerid, "D", close)  // pine-ignore: S1\nplot(d)\n',
+    expect: null,
+    found: '2026-08-07',
+    why: 'Without an escape hatch, one wrong warning becomes a reason to abandon the tool.',
+  },
+  {
+    name: 'a directive inside a STRING is data, not a directive',
+    code: IND + 'msg = "use // pine-ignore: S1 to silence"\n' +
+      'd = request.security(syminfo.tickerid, "D", close)\nplot(d)\n',
+    expect: 'S1',
+    found: '2026-08-07',
+    why: 'Otherwise file content could silently disable the validator.',
+  },
+  {
+    name: 'a typo in the directive suppresses nothing rather than everything',
+    code: IND + 'd = request.security(syminfo.tickerid, "D", close)  // pine-ignore: S99\nplot(d)\n',
+    expect: 'S1',
+    found: '2026-08-07',
+    why: 'Widening a typo into a blanket suppression would hide real findings.',
+  },
+  {
+    name: 'a compile error survives any directive',
+    code: IND + 'l = line.new(x1=1, y1=2, x2=3, y2=4, colour=color.red)  // pine-ignore\n',
+    expect: 'error',
+    found: '2026-08-07',
+    why: 'A compile error is a fact, not a judgement. Hiding it ships a script that cannot run.',
+  },
+];
+
+module.exports = { CASES, SUPPRESSION_CASES, IND, STR };

--- a/test/regression-corpus.test.js
+++ b/test/regression-corpus.test.js
@@ -1,0 +1,85 @@
+/**
+ * The regression corpus, run against the LOCAL BUILD.
+ *
+ * The same table also runs against the packed-and-installed tarball in
+ * test/npm-package.test.js. Two runs, one table: a defect that only appears in the
+ * published artefact cannot hide, and the two runs cannot drift apart because there
+ * is nothing to drift.
+ *
+ * Cases live in test/regression-corpus.js. Add them there, not here.
+ */
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { validatePineScript } = require('../packages/validator/dist/index.js');
+const { CASES, SUPPRESSION_CASES } = require('./regression-corpus.js');
+
+/**
+ * Run one corpus case and explain any failure in terms of the ORIGINAL defect.
+ * A bare "expected S3, got nothing" tells a future maintainer nothing about why
+ * the case exists; `why` is the whole value of the corpus.
+ */
+function runCase(validate, entry) {
+  const diagnostics = validate(entry.code);
+  const ids = diagnostics.map(d => d.checkId || (d.severity === 0 ? 'error' : 'warn'));
+
+  const context =
+    `\n\n  Regression found ${entry.found}` +
+    `\n  ${entry.why}` +
+    `\n\n  Got: ${ids.join(', ') || '(nothing)'}`;
+
+  if (entry.expect === null) {
+    const real = diagnostics.filter(d => d.checkId || d.severity === 0);
+    assert.strictEqual(real.length, 0,
+      `This code is CORRECT and must produce no findings.` + context +
+      `\n  A false positive on working code is worse than a miss — it teaches ` +
+      `people to ignore the tool.`);
+    return;
+  }
+
+  assert.ok(ids.includes(entry.expect),
+    `Expected ${entry.expect}.` + context);
+}
+
+describe('Regression corpus — local build', () => {
+  for (const entry of CASES) {
+    test(entry.name, () => runCase(validatePineScript, entry));
+  }
+});
+
+describe('Regression corpus — suppression contract', () => {
+  for (const entry of SUPPRESSION_CASES) {
+    test(entry.name, () => runCase(validatePineScript, entry));
+  }
+});
+
+describe('Regression corpus — integrity of the corpus itself', () => {
+  const all = [...CASES, ...SUPPRESSION_CASES];
+
+  test('every case documents when it was found and why it exists', () => {
+    for (const entry of all) {
+      assert.match(entry.found, /^\d{4}-\d{2}-\d{2}$/,
+        `"${entry.name}" needs a real date in \`found\`, not "${entry.found}"`);
+      assert.ok(entry.why && entry.why.length > 40,
+        `"${entry.name}" needs a \`why\` explaining how the defect escaped. ` +
+        `A case nobody understands is a case somebody deletes.`);
+    }
+  });
+
+  test('the corpus keeps a real proportion of must-not-fire cases', () => {
+    // Every check ships with both directions. If negatives ever fall away, the
+    // corpus has quietly become a "find more bugs" suite and stopped defending
+    // correct code — which is the harder and more valuable half.
+    const negatives = all.filter(c => c.expect === null).length;
+    assert.ok(negatives >= all.length * 0.3,
+      `Only ${negatives}/${all.length} cases assert silence on correct code.`);
+  });
+
+  test('case names are unique', () => {
+    const names = all.map(c => c.name);
+    assert.strictEqual(new Set(names).size, names.length, 'duplicate case name');
+  });
+});

--- a/test/semantic-checks.test.js
+++ b/test/semantic-checks.test.js
@@ -77,6 +77,37 @@ test('S2 is silent when the RESULT of an unconditional call is used in a ternary
     'This is the correct idiom and by far the more common shape — flagging it would be the worst kind of false positive');
 });
 
+// Indentation is not conditionality. A user-defined function body is indented for
+// SCOPE, and `ta.*` inside one is the normal way to write a reusable helper — it
+// runs whenever the function is called. Flagging it fired on real working scripts
+// (examples/global-liquidity.v6.pine:41), which is the false-positive class this
+// project holds to be worse than a miss.
+
+test('S2 is silent for a ta.* call in a user-defined function body', () => {
+  assertSilent(IND + 'f_norm(x, n) =>\n    ma = ta.sma(x, n)\n    na(ma) ? na : x / ma\nplot(f_norm(close, 20))\n',
+    'S2', 'A function body is indented for scope, not for branching');
+});
+
+test('S2 is silent for a ta.* call in a method body', () => {
+  assertSilent(IND + 'method smooth(float x) =>\n    ta.sma(x, 5)\nplot(close.smooth())\n',
+    'S2', 'Methods are function definitions too');
+});
+
+test('S2 is silent for a ta.* call in an exported function body', () => {
+  assertSilent(IND + 'export f(float x) =>\n    ta.rsi(x, 14)\nplot(close)\n',
+    'S2', 'export is a modifier on a definition, not a branch');
+});
+
+test('S2 still flags a ta.* call inside an if NESTED in a function', () => {
+  assertFlags(IND + 'f(x) =>\n    if x > 0\n        ta.sma(x, 5)\nplot(f(close))\n',
+    'S2', 'The nearest enclosing block is the if — the function around it is irrelevant');
+});
+
+test('S2 flags a ta.* call inside a for body', () => {
+  assertFlags(IND + 'var float v = 0.0\nfor i = 0 to 2\n    v := ta.ema(close, 20)\nplot(v)\n',
+    'S2', 'Loop iterations are not bars — calling ta.* n times per bar corrupts its state');
+});
+
 test('S2 is silent for a ta.* call at global scope', () => {
   assertSilent(IND + 'x = ta.sma(close, 14)\nplot(x)\n', 'S2', 'Unconditional is correct');
 });
@@ -144,6 +175,52 @@ test('S8 is silent for a function at root indentation', () => {
 test('S8 is silent for an indented function CALL', () => {
   assertSilent(IND + 'if close > open\n    y = math.max(1, 2)\n    plot(na)\n', 'S8',
     'A call is not a definition — the => arrow is what distinguishes them');
+});
+
+//──────────────────────────────────────────────────────────
+// S3 — accumulator lifetime
+//
+// Found in the field on 2026-08-08: every layer of this system read
+// examples/test-v6-features.pine and none of them noticed that a `var` total was
+// being re-accumulated on every bar. The original S3 spec covered only the opposite
+// shape (an accumulator MISSING `var`), which is the cheaper of the two — it
+// produces a visibly constant series. This one produces a plausible number that
+// drifts, which is the defect that survives a backtest.
+//──────────────────────────────────────────────────────────
+
+test('S3 flags a var total re-accumulated by a for loop every bar', () => {
+  assertFlags(IND + 'var float sum = 0.0\nfor i = 0 to 9\n    sum := sum + close[i]\nplot(sum)\n',
+    'S3', 'var persists across bars, so this adds ten more closes on every bar, forever');
+});
+
+test('S3 flags a var counter whose while loop can never run again', () => {
+  assertFlags(IND + 'var int counter = 0\nwhile counter < 5\n    counter += 1\nplot(counter)\n',
+    'S3', 'On bar 2 counter is already 5 and the loop body is dead');
+});
+
+test('S3 is silent when the per-bar total correctly omits var', () => {
+  assertSilent(IND + 'float sum = 0.0\nfor i = 0 to 9\n    sum += close[i]\nplot(sum)\n',
+    'S3', 'No var means it resets each bar — which is exactly what a per-bar total wants');
+});
+
+test('S3 is silent when the accumulator is reset before the loop', () => {
+  assertSilent(IND + 'var float sum = 0.0\nsum := 0.0\nfor i = 0 to 9\n    sum += close[i]\nplot(sum)\n',
+    'S3', 'A var reused as a buffer is correct provided it is cleared every bar');
+});
+
+test('S3 is silent for run-once initialisation on the first bar', () => {
+  assertSilent(IND + 'var float seed = 0.0\nif barstate.isfirst\n    for i = 0 to 9\n        seed += close[i]\nplot(seed)\n',
+    'S3', 'Building a table on bar one is the legitimate reason to accumulate into a var');
+});
+
+test('S3 is silent for a genuine running total outside any loop', () => {
+  assertSilent(IND + 'var float total = 0.0\ntotal := total + volume\nplot(total)\n',
+    'S3', 'Cumulative volume is the textbook correct use of var — flagging it would be absurd');
+});
+
+test('S3 does not fire merely because a var and a loop coexist', () => {
+  assertSilent(IND + 'var float sum = 0.0\nfor i = 0 to 9\n    x = close[i]\nplot(sum)\n',
+    'S3', 'The loop must actually assign the accumulator to itself');
 });
 
 //──────────────────────────────────────────────────────────

--- a/test/suppression.test.js
+++ b/test/suppression.test.js
@@ -33,8 +33,13 @@ test('every check carries an id, severity, title and doc anchor', () => {
     assert.strictEqual(check.id, id, `${id}: id must match its key`);
     assert.ok([0, 1, 2, 3].includes(check.severity), `${id}: severity`);
     assert.ok(check.title && check.title.length > 15, `${id}: needs a real title`);
-    assert.ok(check.docAnchor && check.docAnchor.includes('#'),
-      `${id}: docAnchor must point into a skill section`);
+    // Shape only. Whether the anchor RESOLVES is checked where the skills
+    // actually live — scripts/check_doc_anchors.js in pinescript-plugin. Asserting
+    // `includes('#')` here passed happily while four of the nine anchors pointed at
+    // headings that no longer existed, so treat this as a typo guard, not a link check.
+    const [skill, anchor] = (check.docAnchor || '').split('#');
+    assert.match(skill, /^pinescript-[a-z0-9]+$/, `${id}: docAnchor needs a skill name`);
+    assert.ok(anchor && anchor.length > 3, `${id}: docAnchor needs a section`);
   }
 });
 


### PR DESCRIPTION
Engine `0.3.0` (published) · extension `0.6.2`

## What prompted this

A user validated `examples/test-v6-features.pine`, got a clean-ish report, then found by eye what the tool had missed:

```pine
var float sum = 0.0
for i = 0 to 9
    sum := sum + close[i]
```

`var` persists across bars, so this adds ten more closes on every bar for the life of the chart. A second instance in the same file was quieter — `var int counter = 0` guarding `while counter < 5`, which on bar two can never run again.

The spec had only the **opposite** shape: an accumulator *missing* `var`. That is the cheaper half — it produces a visibly constant series. This half produces a plausible number that drifts, which is the defect that survives a backtest.

## Changes

**S3 — new check.** Two exemptions keep it quiet on correct code: a reset before the loop (a `var` reused as a buffer) and a run-once guard (`barstate.isfirst`, `bar_index == 0`) for table-building on bar one. Seven paired tests. Fires twice across 24 committed `.pine` files; both are real defects.

**S2 — false positive fixed.** It flagged *any* indented `ta.*`, including user-defined function bodies, which are indented for scope rather than branching. It fired on a real working script (`examples/global-liquidity.v6.pine:41`). S2 now resolves the nearest enclosing construct; an `if` nested inside a function still flags. Five new tests.

**Doc anchors.** Four of nine pointed at headings that no longer existed, including S1's. The guarding test asserted `docAnchor.includes('#')`, which all four dead links passed. Resolution is now enforced by `make anchors` in the plugin repo.

**Regression harness.** `test/regression-corpus.js` holds every defect this validator has shipped, as data, run against both the local build and the **packed, installed tarball**. Every recurring failure here has been "correct in `src/`, broken in what users receive" — no suite importing from `packages/validator/dist` can see that class.

**Lockfile drift.** `package-lock.json` had silently diverged by two releases. CI installs with `npm ci`, which refuses to run on a mismatch — it would have broken every job at the install step. `npm run audit` now fails on it.

## Verification

Every guard was proved by breaking something on purpose: reintroducing the S2 false positive fails both corpus runs by name; staging it is refused by the pre-commit hook; a local tarball path fails the manifest check; fixing a negative fixture fails the examples suite.

Two of the new guards were themselves vacuous when first written and were rewritten — the "no local path dependency" check tested only the published manifest, which has no dependencies at all.

**291 tests, 0 failures.** `examples/`: 13 files, 0 false positives.